### PR TITLE
Add more Cadence tooling in docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/pages/community.js
+++ b/pages/community.js
@@ -44,8 +44,8 @@ export default function Community() {
                     <li>
                         <strong>
                             <span className='icon'>💭</span> Joining
-                            the <a href="https://docs.google.com/document/d/1KMGdiZ7qX9aoyH2WEVGHjsvBTNPTN6my8LcNmSVivLQ/edit">Cadence Language Design Meetings</a>
-                            to discuss the design and implementation of Cadence.
+                            the <a href="https://docs.google.com/document/d/1KMGdiZ7qX9aoyH2WEVGHjsvBTNPTN6my8LcNmSVivLQ/edit">Cadence Language Design Meetings</a> to
+                            discuss the design and implementation of Cadence.
                         </strong>
                         <p>
                             In the meetings, the core contributors and the community investigate, design, and ultimately decide on language features.

--- a/pages/index.js
+++ b/pages/index.js
@@ -201,6 +201,12 @@ export default function Home() {
                   like <a href="https://marketplace.visualstudio.com/items?itemName=onflow.cadence">Visual Studio Code</a>,
                   Vim or Emacs, to get diagnostics, code completion, refactoring support, and more.
                 </p>
+                <p>
+                  To further enhance the developer experience, there is also a
+                  native testing framework, which allows developers to write
+                  unit & integration tests using Cadence. The framework can
+                  also generate code coverage insights.
+                </p>
               </div>
               <div>
                 <Lottie animationData={debuggingAnimation} />


### PR DESCRIPTION
Adds a new paragraph in the `Best-In-Class Tooling` section, to list the testing framework & code coverage tools.