### PR TITLE
Add Solidity Guide link to the top navigation bar

### DIFF
--- a/components/navigation.js
+++ b/components/navigation.js
@@ -21,6 +21,12 @@ export default function Navigation() {
             <a
                 target="_blank"
                 rel="noopener noreferrer"
+                href="https://developers.flow.com/cadence/solidity-to-cadence"
+            >Solidity Guide</a>
+            
+            <a
+                target="_blank"
+                rel="noopener noreferrer"
                 href="https://play.flow.com/"
             >Playground</a>
 


### PR DESCRIPTION
Work towards #8 - fixes first issue (second needs to be done in the onflow/docs repo)

