### PR TITLE
Update testing-framework.mdx linking the Run Cadence tests section of Flow-cli docs

### DIFF
--- a/docs/testing-framework.mdx
+++ b/docs/testing-framework.mdx
@@ -7,7 +7,7 @@ The Cadence testing framework provides a convenient way to write tests for Caden
 This functionality is provided by the built-in `Test` contract.
 
 <Callout type="info">
-The testing framework can only be used off-chain, e.g. by using the [Flow CLI](https://developers.flow.com/tools/flow-cli).
+The testing framework can only be used off-chain, e.g. by using the [Flow CLI](https://developers.flow.com/tools/flow-cli/tests/run-tests).
 </Callout>
 
 Tests must be written in the form of a Cadence script.


### PR DESCRIPTION
Point the Flow-cli link to the Run Cadence tests section