### PR TITLE
Updating config to remove misleading version banner

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -51,6 +51,7 @@ const config = {
             },
             '1.0': {
               label: '1.0',
+              banner: "none"
             }
           },
           beforeDefaultRemarkPlugins: [


### PR DESCRIPTION
work towards https://github.com/onflow/cadence-lang.org/issues/21

This is a quick fix to remove misleading message, ned to come up with a way to customize the docusaurus banner, will do that in a follow-up PR.