### PR TITLE
Fix styling

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -306,22 +306,21 @@ p {
   margin: 1rem 0;
 }
 
-
-main {
-  font-weight: 400;
+body {
+  font-weight: 300;
   font-size: 1rem;
   line-height: 1.75rem;
 }
 
-main ul {
+ul {
   list-style: disc outside;
 }
 
-main li {
+li {
   margin-left: 1.8rem;
 }
 
-main a {
+a {
   color: #00c271;
 }
 


### PR DESCRIPTION
The move to Docusaurus broke the styling of e.g. links on existing non-documentation pages, like "Community" - they were not colored at all, and looked exactly like normal links ... see e.g. https://cadence-lang.org/community

Restore the styling by removing the scope to the `main` element