### PR TITLE
update KeyList's verify function

### DIFF
--- a/versioned_docs/version-1.0/language/crypto.mdx
+++ b/versioned_docs/version-1.0/language/crypto.mdx
@@ -201,12 +201,6 @@ The validation of the public key depends on the supported signature scheme:
   The coordinates represent valid prime field extension elements. The resulting point is on the curve, and is on the correct subgroup G_2.
   Note that the point at infinity is accepted and yields the identity public key. Such identity key can be useful when aggregating multiple keys.
 
-<Callout type="info">
-
-🚧 Status: Accepting the BLS identity key is going to be available in the upcoming release of Cadence on Mainnet.
-
-</Callout>
-
 Since the validation happens only at the time of creation, public keys are immutable.
 
 ```cadence
@@ -266,13 +260,6 @@ A valid signature would be generated using the expected `signedData`, `domainSep
 
 BLS verification performs the necessary membership check on the signature while the membership check of the public key is performed at the creation of the `PublicKey` object
 and is not repeated during the signature verification. In order to prevent equivocation issues, a verification under the identity public key always returns `false`.
-
-<Callout type="info">
-
-🚧 Status: Returning `false` when verifying against a BLS identity key is going to be available in the upcoming release of Cadence on Mainnet.
-Currently, BLS identity keys can only be constructed as an output of `aggregatePublicKeys`.
-
-</Callout>
 
 The verificaction uses a hash-to-curve algorithm to hash the `signedData` into a `G_1` point, following the `hash_to_curve` method described in the [draft-irtf-cfrg-hash-to-curve-14](https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-hash-to-curve-14#section-3).
 While KMAC128 is used as a hash-to-field method resulting in two field elements, the mapping to curve is implemented using the [simplified SWU](https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-hash-to-curve-14#section-6.6.3).
@@ -396,7 +383,8 @@ fun test main() {
 
     let isValid = keyList.verify(
         signatureSet: signatureSet,
-        signedData: signedData
+        signedData: signedData,
+        domainSeparationTag: "FLOW-V0.0-user",
     )
 }
 ```
@@ -455,10 +443,13 @@ struct KeyList {
     fun revoke(keyIndex: Int)
 
     /// Returns true if the given signatures are valid for the given signed data
+    /// `domainSeparationTag` is used to specify a scope for each signature,
+    /// and is implemented the same way as `PublicKey`'s verify function.
     access(all)
     fun verify(
         signatureSet: [KeyListSignature],
-        signedData: [UInt8]
+        signedData: [UInt8],
+        domainSeparationTag: String
     ): Bool
 }
 


### PR DESCRIPTION
Update `KeyList` example and header with regards to the `verify` function and its new `domainSeparationTag` parameter.

- Side change: remove old call outs of already deployed behaviour