### PR TITLE
add callouts for important contracts

### DIFF
--- a/docs/cadence_migration_guide/core-contracts-guide.mdx
+++ b/docs/cadence_migration_guide/core-contracts-guide.mdx
@@ -24,7 +24,12 @@ Please look at the changes there to understand how the contracts have changed.
 Every contract in the repo is changing.
 
 Please see the latest post in [this forum thread](https://forum.flow.com/t/update-on-cadence-1-0/5197/8)
-to find the latest version of the CLI and emulator that you should be testing with,
+to find the latest version of the CLI and emulator that you should be testing with.
+
+It is also important to remember that after you've made your changes to your contracts,
+you will have to stage the upgrades on testnet and mainnet in order for them
+to be upgraded and migrated properly. You can find informaion about how to do that
+here: https://github.com/onflow/contract-updater
 
 Additionally, here are the import addresses
 for all of the important contracts related to the protocol:

--- a/docs/cadence_migration_guide/ft-guide.mdx
+++ b/docs/cadence_migration_guide/ft-guide.mdx
@@ -43,7 +43,12 @@ This branch also includes the updated versions of `FungibleTokenMetadataViews`,
 `Burner`, `FungibleTokenSwitchboard`, and `TokenForwarding`.
 
 Please see the latest post in [this forum thread](https://forum.flow.com/t/update-on-cadence-1-0/5197/8)
-to find the latest version of the CLI and emulator that you should be testing with,
+to find the latest version of the CLI and emulator that you should be testing with.
+
+It is also important to remember that after you've made your changes to your contracts,
+you will have to stage the upgrades on testnet and mainnet in order for them
+to be upgraded and migrated properly. You can find informaion about how to do that
+here: https://github.com/onflow/contract-updater
 
 Additionally, here are the import addresses
 for all of the important contracts related to fungible tokens:

--- a/docs/cadence_migration_guide/ft-guide.mdx
+++ b/docs/cadence_migration_guide/ft-guide.mdx
@@ -60,6 +60,19 @@ for all of the important contracts related to fungible tokens:
 See the other guides in this section of the docs for the import
 addresses of other important contracts in the emulator.
 
+As for contracts that are important for NFT developers but aren't "core contracts",
+here is information about where to find the Cadence 1.0 Versions of Each:
+
+**USDC:** The USDC contract is still being updated for Cadence 1.0 and is currently not available.
+
+**Account Linking and Hybrid Custody:** The account linking and hybrid custody contracts
+are still being updated for Cadence 1.0 and are currently not available.
+
+For any other contracts, search for their github repo and there will likely be
+a PR or feature branch with the Cadence 1.0 changes. If there isn't, please
+create an issue in the repo or reach out to that team directly via their support
+or Discord channel to ask them about their plans to update their contracts.
+
 # Migration Guide
 
 Please see the [NFT Cadence 1.0 migration guide](./nft-guide). While

--- a/docs/cadence_migration_guide/nft-guide.mdx
+++ b/docs/cadence_migration_guide/nft-guide.mdx
@@ -47,7 +47,12 @@ This branch includes the updated versions of `NonFungibleToken`, `MetadataViews`
 and `NFTForwarding`.
 
 Please see the latest post in [this forum thread](https://forum.flow.com/t/update-on-cadence-1-0/5197/8)
-to find the latest version of the CLI and emulator that you should be testing with,
+to find the latest version of the CLI and emulator that you should be testing with.
+
+It is also important to remember that after you've made your changes to your contracts,
+you will have to stage the upgrades on testnet and mainnet in order for them
+to be upgraded and migrated properly. You can find informaion about how to do that
+here: https://github.com/onflow/contract-updater
 
 Additionally, here are the import addresses
 for all of the important contracts related to non-fungible tokens:

--- a/docs/cadence_migration_guide/nft-guide.mdx
+++ b/docs/cadence_migration_guide/nft-guide.mdx
@@ -63,6 +63,25 @@ for all of the important contracts related to non-fungible tokens:
 See the other guides in this section of the docs for the import
 addresses of other important contracts in the emulator.
 
+As for contracts that are important for NFT developers but aren't "core contracts",
+here is information about where to find the Cadence 1.0 Versions of Each:
+
+**NFT Catalog:** See [the `feature/cadence-1.0` branch of the NFT Catalog Repo](https://github.com/onflow/nft-catalog/tree/feature/cadence-1.0/cadence/contracts)
+for the updated versions of NFT Catalog contracts.
+
+**NFT Storefront:** See [the `cadence-1.0` branch in the NFT Storefront Repo](https://github.com/onflow/nft-storefront/tree/cadence-1.0/contracts)
+for the updated versions of the `NFTStorefront` and `NFTStorefrontV2` contracts.
+
+**USDC:** The USDC contract is still being updated for Cadence 1.0 and is currently not available.
+
+**Account Linking and Hybrid Custody:** The account linking and hybrid custody contracts
+are still being updated for Cadence 1.0 and are currently not available.
+
+For any other contracts, search for their github repo and there will likely be
+a PR or feature branch with the Cadence 1.0 changes. If there isn't, please
+create an issue in the repo or reach out to that team directly via their support
+or Discord channel to ask them about their plans to update their contracts.
+
 ## A note for newcomers
 
 This guide is primarily for developers who have existing contracts


### PR DESCRIPTION
Adds information to the NFT migration guide about important contracts that aren't necessarily core contracts