### PR TITLE
update cadence 1.0 json specs with Authorization

### DIFF
--- a/versioned_docs/version-1.0/json-cadence-spec.md
+++ b/versioned_docs/version-1.0/json-cadence-spec.md
@@ -351,7 +351,7 @@ Composite fields are encoded as a list of name-value pairs in the order in which
 {
   "type": "Capability",
   "value": {
-    "path": <path>,
+    "id": "identifier",
     "address": "0x0",  // as hex-encoded string with 0x prefix
     "borrowType": <type>,
   }
@@ -364,13 +364,7 @@ Composite fields are encoded as a list of name-value pairs in the order in which
 {
   "type": "Capability",
   "value": {
-    "path": {
-      "type": "Path",
-      "value": {
-        "domain": "public",
-        "identifier": "someInteger"
-      }
-    },
+    "id": "1",
     "address": "0x1",
     "borrowType": {
       "kind": "Int"

--- a/versioned_docs/version-1.0/json-cadence-spec.md
+++ b/versioned_docs/version-1.0/json-cadence-spec.md
@@ -94,7 +94,6 @@ This format includes less type information than a complete [ABI](https://en.wiki
   "type": "String",
   "value": "..."
 }
-
 ```
 
 ### Example
@@ -130,7 +129,7 @@ This format includes less type information than a complete [ABI](https://en.wiki
 
 ## Integers
 
-`[U]Int`, `[U]Int8`, `[U]Int16`, `[U]Int32`,`[U]Int64`,`[U]Int128`, `[U]Int256`,  `Word8`, `Word16`, `Word32`, or `Word64`
+`[U]Int`, `[U]Int8`, `[U]Int16`, `[U]Int32`,`[U]Int64`,`[U]Int128`, `[U]Int256`, `Word8`, `Word16`, `Word32`, or `Word64`
 
 Although JSON supports integer literals up to 64 bits, all integer types are encoded as strings for consistency.
 
@@ -162,8 +161,8 @@ Although fixed point numbers are implemented as integers, JSON-Cadence uses a de
 
 ```json
 {
-    "type": "[U]Fix64",
-    "value": "<integer>.<fractional>"
+  "type": "[U]Fix64",
+  "value": "<integer>.<fractional>"
 }
 ```
 
@@ -171,8 +170,8 @@ Although fixed point numbers are implemented as integers, JSON-Cadence uses a de
 
 ```json
 {
-    "type": "Fix64",
-    "value": "12.3"
+  "type": "Fix64",
+  "value": "12.3"
 }
 ```
 
@@ -248,7 +247,7 @@ Dictionaries are encoded as a list of key-value pairs to preserve the determinis
         "value": "test"
       }
     }
-  ],
+  ]
   // ...
 }
 ```
@@ -285,7 +284,7 @@ Composite fields are encoded as a list of name-value pairs in the order in which
     "fields": [
       {
         "name": "power",
-        "value": {"type": "Int", "value": "1"}
+        "value": { "type": "Int", "value": "1" }
       }
     ]
   }
@@ -338,7 +337,7 @@ Composite fields are encoded as a list of name-value pairs in the order in which
   "type": "Type",
   "value": {
     "staticType": {
-      "kind": "Int",
+      "kind": "Int"
     }
   }
 }
@@ -510,7 +509,7 @@ These are basic types like `Int`, `String`, or `StoragePath`.
   "type": {
     "kind": "String"
   },
-  "size":3
+  "size": 3
 }
 ```
 
@@ -536,7 +535,7 @@ These are basic types like `Int`, `String`, or `StoragePath`.
   },
   "value": {
     "kind": "UInt16"
-  },
+  }
 }
 ```
 
@@ -569,7 +568,7 @@ These are basic types like `Int`, `String`, or `StoragePath`.
   "kind": "Resource",
   "type": "",
   "typeID": "0x3.GreatContract.GreatNFT",
-  "initializers":[
+  "initializers": [
     [
       {
         "label": "foo",
@@ -710,7 +709,14 @@ Initializer types are encoded a list of parameters to the initializer.
 ```json
 {
   "kind": "Reference",
-  "authorized": true | false,
+  "authorization": {
+    "kind": "Unauthorized" | "EntitlementMapAuthorization" | "EntitlementConjunctionSet" | "EntitlementDisjunctionSet",
+    "entitlements": [
+    <entitlement at index 0>,
+    <entitlement at index 1>
+    // ...
+    ]
+    },
   "type": <type>
 }
 ```
@@ -720,7 +726,15 @@ Initializer types are encoded a list of parameters to the initializer.
 ```json
 {
   "kind": "Reference",
-  "authorized": true,
+  "authorization": {
+		{
+			"kind": "EntitlementMap",
+			"typeID": "foo",
+			"type": null,
+			"fields": null,
+			"initializers": null
+		}
+  },
   "type": {
     "kind": "String"
   }
@@ -750,22 +764,22 @@ Initializer types are encoded a list of parameters to the initializer.
   "kind": "Restriction",
   "typeID": "0x3.GreatContract.GreatNFT",
   "type": {
-    "kind": "AnyResource",
+    "kind": "AnyResource"
   },
   "restrictions": [
     {
-        "kind": "ResourceInterface",
-        "typeID": "0x1.FungibleToken.Receiver",
-        "fields": [
-            {
-                "id": "uuid",
-                "type": {
-                    "kind": "UInt64"
-                }
-            }
-        ],
-        "initializers": [],
-        "type": ""
+      "kind": "ResourceInterface",
+      "typeID": "0x1.FungibleToken.Receiver",
+      "fields": [
+        {
+          "id": "uuid",
+          "type": {
+            "kind": "UInt64"
+          }
+        }
+      ],
+      "initializers": [],
+      "type": ""
     }
   ]
 }
@@ -825,7 +839,7 @@ Initializer types are encoded a list of parameters to the initializer.
     "kind": "String"
   },
   "typeID": "0x3.GreatContract.GreatEnum",
-  "initializers":[],
+  "initializers": [],
   "fields": [
     {
       "id": "rawValue",
@@ -847,21 +861,22 @@ represented by its type ID.
 
 ```json
 {
-  "type":"Type",
+  "type": "Type",
   "value": {
     "staticType": {
-      "kind":"Resource",
-      "typeID":"0x3.GreatContract.NFT",
-      "fields":[
-        {"id":"foo",
-        "type": {
-          "kind":"Optional",
-          "type":"0x3.GreatContract.NFT" // recursive NFT resource type is instead encoded as an ID
+      "kind": "Resource",
+      "typeID": "0x3.GreatContract.NFT",
+      "fields": [
+        {
+          "id": "foo",
+          "type": {
+            "kind": "Optional",
+            "type": "0x3.GreatContract.NFT" // recursive NFT resource type is instead encoded as an ID
           }
         }
       ],
-      "initializers":[],
-      "type":""
+      "initializers": [],
+      "type": ""
     }
   }
 }

--- a/versioned_docs/version-1.0/json-cadence-spec.md
+++ b/versioned_docs/version-1.0/json-cadence-spec.md
@@ -345,6 +345,43 @@ Composite fields are encoded as a list of name-value pairs in the order in which
 
 ---
 
+## Inclusive Range Value
+
+```json
+{
+  "type": "InclusiveRange",
+  "value": {
+    "start": <start_value>,
+    "end": <end_value>,
+    "step": <step_type>
+  }
+}
+```
+
+### Example
+
+```json
+{
+  "type": "InclusiveRange",
+  "value": {
+    "start": {
+      "type": "Int256",
+      "value": "10"
+    },
+    "end": {
+      "type": "Int256",
+      "value": "20"
+    },
+    "step": {
+      "type": "Int256",
+      "value": "5"
+    }
+  }
+}
+```
+
+---
+
 ## Capability
 
 ```json
@@ -857,5 +894,25 @@ represented by its type ID.
       "type": ""
     }
   }
+}
+```
+
+## Inclusive Range Type
+
+### Example
+
+```json
+{
+	{
+	"type": "Type",
+	"value": {
+		"staticType": {
+		"kind": "InclusiveRange",
+		"element": {
+			"kind": "Int"
+		}
+		}
+	}
+	}
 }
 ```

--- a/versioned_docs/version-1.0/json-cadence-spec.md
+++ b/versioned_docs/version-1.0/json-cadence-spec.md
@@ -896,23 +896,3 @@ represented by its type ID.
   }
 }
 ```
-
-## Inclusive Range Type
-
-### Example
-
-```json
-{
-	{
-	"type": "Type",
-	"value": {
-		"staticType": {
-		"kind": "InclusiveRange",
-		"element": {
-			"kind": "Int"
-		}
-		}
-	}
-	}
-}
-```

--- a/versioned_docs/version-1.0/json-cadence-spec.md
+++ b/versioned_docs/version-1.0/json-cadence-spec.md
@@ -800,7 +800,18 @@ Initializer types are encoded a list of parameters to the initializer.
   "typeID": "0x3.GreatContract.GreatNFT",
   "types": [
     {
-      "kind": "String"
+      "kind": "ResourceInterface",
+      "typeID": "0x1.FungibleToken.Receiver",
+      "fields": [
+        {
+          "id": "uuid",
+          "type": {
+            "kind": "UInt64"
+          }
+        }
+      ],
+      "initializers": [],
+      "type": ""
     }
   ]
 }
@@ -823,7 +834,14 @@ Initializer types are encoded a list of parameters to the initializer.
 {
   "kind": "Capability",
   "type": {
-    "kind": "String"
+    "kind": "Reference",
+    "authorization": {
+      "kind": "Unauthorized",
+      "entitlements": null
+    },
+    "type": {
+      "kind": "String"
+    }
   }
 }
 ```
@@ -904,7 +922,7 @@ represented by its type ID.
 ```json
 {
   "kind": "InclusiveRange",
-  "element":  <integer_value>
+  "element":  <integer_type>
 }
 ```
 

--- a/versioned_docs/version-1.0/json-cadence-spec.md
+++ b/versioned_docs/version-1.0/json-cadence-spec.md
@@ -763,27 +763,11 @@ Initializer types are encoded a list of parameters to the initializer.
 
 ```json
 {
-  "kind": "Restriction",
+  "kind": "Intersection",
   "typeID": "0x3.GreatContract.GreatNFT",
   "type": {
     "kind": "AnyResource"
-  },
-  "restrictions": [
-    {
-      "kind": "ResourceInterface",
-      "typeID": "0x1.FungibleToken.Receiver",
-      "fields": [
-        {
-          "id": "uuid",
-          "type": {
-            "kind": "UInt64"
-          }
-        }
-      ],
-      "initializers": [],
-      "type": ""
-    }
-  ]
+  }
 }
 ```
 

--- a/versioned_docs/version-1.0/json-cadence-spec.md
+++ b/versioned_docs/version-1.0/json-cadence-spec.md
@@ -765,9 +765,11 @@ Initializer types are encoded a list of parameters to the initializer.
 {
   "kind": "Intersection",
   "typeID": "0x3.GreatContract.GreatNFT",
-  "type": {
-    "kind": "AnyResource"
-  }
+  "types": [
+    {
+      "kind": "String"
+    }
+  ]
 }
 ```
 
@@ -788,11 +790,7 @@ Initializer types are encoded a list of parameters to the initializer.
 {
   "kind": "Capability",
   "type": {
-    "kind": "Reference",
-    "authorized": true,
-    "type": {
-      "kind": "String"
-    }
+    "kind": "String"
   }
 }
 ```

--- a/versioned_docs/version-1.0/json-cadence-spec.md
+++ b/versioned_docs/version-1.0/json-cadence-spec.md
@@ -912,14 +912,9 @@ represented by its type ID.
 
 ```json
 {
-	{
-	"type": "Type",
-	"value": {
-		"kind": "InclusiveRange",
-		"element": {
-			"kind": "Int"
-		}
-	}
-	}
+  "kind": "InclusiveRange",
+  "element": {
+    "kind": "Int"
+  }
 }
 ```

--- a/versioned_docs/version-1.0/json-cadence-spec.md
+++ b/versioned_docs/version-1.0/json-cadence-spec.md
@@ -896,3 +896,30 @@ represented by its type ID.
   }
 }
 ```
+
+## Inclusive Range Type
+
+```json
+{
+  "kind": "InclusiveRange",
+  "element":  <integer_value>
+}
+```
+
+### Example
+
+```json
+{
+	{
+	"type": "Type",
+	"value": {
+		"staticType": {
+		"kind": "InclusiveRange",
+		"element": {
+			"kind": "Int"
+		}
+		}
+	}
+	}
+}
+```

--- a/versioned_docs/version-1.0/json-cadence-spec.md
+++ b/versioned_docs/version-1.0/json-cadence-spec.md
@@ -708,6 +708,7 @@ Initializer types are encoded a list of parameters to the initializer.
     <parameter at index 1>,
     // ...
   ],
+  "purity: "view",
   "return": <type>
 }
 ```
@@ -727,6 +728,7 @@ Initializer types are encoded a list of parameters to the initializer.
       }
     }
   ],
+  "purity": "view",
   "return": {
     "kind": "String"
   }

--- a/versioned_docs/version-1.0/json-cadence-spec.md
+++ b/versioned_docs/version-1.0/json-cadence-spec.md
@@ -728,11 +728,13 @@ Initializer types are encoded a list of parameters to the initializer.
   "kind": "Reference",
   "authorization": {
 		{
-			"kind": "EntitlementMap",
-			"typeID": "foo",
-			"type": null,
-			"fields": null,
-			"initializers": null
+			"kind": "EntitlementMapAuthorization",
+      "entitlements": [
+        {
+          "kind": "EntitlementMap",
+			    "typeID": "foo",
+        }
+      ]
 		}
   },
   "type": {

--- a/versioned_docs/version-1.0/json-cadence-spec.md
+++ b/versioned_docs/version-1.0/json-cadence-spec.md
@@ -727,15 +727,15 @@ Initializer types are encoded a list of parameters to the initializer.
 {
   "kind": "Reference",
   "authorization": {
-		{
-			"kind": "EntitlementMapAuthorization",
+    {
+      "kind": "EntitlementMapAuthorization",
       "entitlements": [
         {
           "kind": "EntitlementMap",
-			    "typeID": "foo",
+          "typeID": "foo"
         }
       ]
-		}
+    }
   },
   "type": {
     "kind": "String"

--- a/versioned_docs/version-1.0/json-cadence-spec.md
+++ b/versioned_docs/version-1.0/json-cadence-spec.md
@@ -708,7 +708,7 @@ Initializer types are encoded a list of parameters to the initializer.
     <parameter at index 1>,
     // ...
   ],
-  "purity: "view" | undefined,
+  "purity: "view" | "",
   "return": <type>
 }
 ```

--- a/versioned_docs/version-1.0/json-cadence-spec.md
+++ b/versioned_docs/version-1.0/json-cadence-spec.md
@@ -345,7 +345,7 @@ Composite fields are encoded as a list of name-value pairs in the order in which
 
 ---
 
-## Inclusive Range Value
+## InclusiveRange
 
 ```json
 {
@@ -353,7 +353,7 @@ Composite fields are encoded as a list of name-value pairs in the order in which
   "value": {
     "start": <start_value>,
     "end": <end_value>,
-    "step": <step_type>
+    "step": <step_value>
   }
 }
 ```
@@ -708,7 +708,7 @@ Initializer types are encoded a list of parameters to the initializer.
     <parameter at index 1>,
     // ...
   ],
-  "purity: "view",
+  "purity: "view" | undefined,
   "return": <type>
 }
 ```
@@ -915,11 +915,9 @@ represented by its type ID.
 	{
 	"type": "Type",
 	"value": {
-		"staticType": {
 		"kind": "InclusiveRange",
 		"element": {
 			"kind": "Int"
-		}
 		}
 	}
 	}

--- a/versioned_docs/version-1.0/json-cadence-spec.md
+++ b/versioned_docs/version-1.0/json-cadence-spec.md
@@ -797,7 +797,7 @@ Initializer types are encoded a list of parameters to the initializer.
 ```json
 {
   "kind": "Intersection",
-  "typeID": "0x3.GreatContract.GreatNFT",
+  "typeID": "{0x1.FungibleToken.Receiver}",
   "types": [
     {
       "kind": "ResourceInterface",


### PR DESCRIPTION
https://github.com/onflow/cadence/issues/3244


`Restricted` is already removed, so we just need to change `authorized` to `authorizations`
