### PR TITLE
Update various docs with latest Cadence 1.0 knowledge

### DIFF
--- a/versioned_docs/version-1.0/cadence-migration-guide/core-contracts-guide.mdx
+++ b/versioned_docs/version-1.0/cadence-migration-guide/core-contracts-guide.mdx
@@ -34,26 +34,26 @@ here: https://github.com/onflow/contract-updater
 Additionally, here are the import addresses
 for all of the important contracts related to the protocol:
 
-| Contract                    | Emulator Import Address |
-| --------------------------- | ----------------------- |
-| `FungibleToken`             | `0xee82856bf20e2aa6`    |
-| `ViewResolver`              | `0xf8d6e0586b0a20c7`    |
-| `Burner`                    | `0xf8d6e0586b0a20c7`    |
-| `MetadataViews`             | `0xf8d6e0586b0a20c7`    |
-| `FungibleTokenMetadataViews`| `0xee82856bf20e2aa6`    |
-| `FlowToken`                 | `0x0ae53cb6e3f42a79`    |
-| `FlowFees`                  | `0xe5a8b7f23e8b548f`    |
-| `FlowStorageFees`           | `0xf8d6e0586b0a20c7`    |
-| `FlowServiceAccount`        | `0xf8d6e0586b0a20c7`    |
-| `NodeVersionBeacon`         | `0xf8d6e0586b0a20c7`    |
-| `RandomBeaconHistory`       | `0xf8d6e0586b0a20c7`    |
-| `LockedTokens`              | `0xf8d6e0586b0a20c7`    |
-| `StakingProxy`              | `0xf8d6e0586b0a20c7`    |
-| `FlowIDTableStaking`        | `0xf8d6e0586b0a20c7`    |
-| `FlowClusterQC`             | `0xf8d6e0586b0a20c7`    |
-| `FlowDKG`                   | `0xf8d6e0586b0a20c7`    |
-| `FlowEpoch`                 | `0xf8d6e0586b0a20c7`    |
-| `FlowStakingCollection`     | `0xf8d6e0586b0a20c7`    |
+| Contract                    | Emulator Import Address | Testing Framework    |
+| --------------------------- | ----------------------- | -------------------- |
+| `FungibleToken`             | `0xee82856bf20e2aa6`    | `0x0000000000000002` |
+| `ViewResolver`              | `0xf8d6e0586b0a20c7`    | `0x0000000000000001` |
+| `Burner`                    | `0xf8d6e0586b0a20c7`    | `0x0000000000000001` |
+| `MetadataViews`             | `0xf8d6e0586b0a20c7`    | `0x0000000000000001` |
+| `FungibleTokenMetadataViews`| `0xee82856bf20e2aa6`    | `0x0000000000000002` |
+| `FlowToken`                 | `0x0ae53cb6e3f42a79`    | `0x0000000000000003` |
+| `FlowFees`                  | `0xe5a8b7f23e8b548f`    | `0x0000000000000004` |
+| `FlowStorageFees`           | `0xf8d6e0586b0a20c7`    | `0x0000000000000001` |
+| `FlowServiceAccount`        | `0xf8d6e0586b0a20c7`    | `0x0000000000000001` |
+| `NodeVersionBeacon`         | `0xf8d6e0586b0a20c7`    | `0x0000000000000001` |
+| `RandomBeaconHistory`       | `0xf8d6e0586b0a20c7`    | `0x0000000000000001` |
+| `LockedTokens`              | `0xf8d6e0586b0a20c7`    | `0x0000000000000001` |
+| `StakingProxy`              | `0xf8d6e0586b0a20c7`    | `0x0000000000000001` |
+| `FlowIDTableStaking`        | `0xf8d6e0586b0a20c7`    | `0x0000000000000001` |
+| `FlowClusterQC`             | `0xf8d6e0586b0a20c7`    | `0x0000000000000001` |
+| `FlowDKG`                   | `0xf8d6e0586b0a20c7`    | `0x0000000000000001` |
+| `FlowEpoch`                 | `0xf8d6e0586b0a20c7`    | `0x0000000000000001` |
+| `FlowStakingCollection`     | `0xf8d6e0586b0a20c7`    | `0x0000000000000001` |
 
 See the other guides in this section of the docs for the import
 addresses of other important contracts in the emulator.
@@ -64,4 +64,7 @@ The NFT guide covers a lot of common changes that are required for NFT contracts
 but many of these changes will also apply to any contract on Flow, so it is still
 useful to read even if you don't have an NFT contract.
 
-More detailed information about how the core contracts are changing will come soon!
+The core contracts do not have any meaningful changes outside of what is required
+to be compatible with Cadence 1.0 and the token standard changes.
+If you have questions about the core contracts changes for Cadence 1.0, please
+reach out to the flow team in discord and we will be happy to help.

--- a/versioned_docs/version-1.0/cadence-migration-guide/ft-guide.mdx
+++ b/versioned_docs/version-1.0/cadence-migration-guide/ft-guide.mdx
@@ -51,16 +51,18 @@ to be upgraded and migrated properly. You can find informaion about how to do th
 here: https://github.com/onflow/contract-updater
 
 Additionally, here are the import addresses
-for all of the important contracts related to fungible tokens:
+for all of the important contracts related to fungible tokens.
+The second column is the import address if you are testing with a basic version of the emulator.
+The third column contains the import addresses if you are using the Cadence testing framework.
 
-| Contract                    | Emulator Import Address |
-| --------------------------- | ----------------------- |
-| `FungibleToken`             | `0xee82856bf20e2aa6`    |
-| `ViewResolver`              | `0xf8d6e0586b0a20c7`    |
-| `Burner`                    | `0xf8d6e0586b0a20c7`    |
-| `MetadataViews`             | `0xf8d6e0586b0a20c7`    |
-| `FungibleTokenMetadataViews`| `0xee82856bf20e2aa6`    |
-| `FungibleTokenSwitchboard`  | `0xee82856bf20e2aa6`    |
+| Contract                    | Emulator Import Address | Testing Framework    |
+| --------------------------- | ----------------------- | -------------------- |
+| `FungibleToken`             | `0xee82856bf20e2aa6`    | `0x0000000000000002` |
+| `ViewResolver`              | `0xf8d6e0586b0a20c7`    | `0x0000000000000001` |
+| `Burner`                    | `0xf8d6e0586b0a20c7`    | `0x0000000000000001` |
+| `MetadataViews`             | `0xf8d6e0586b0a20c7`    | `0x0000000000000001` |
+| `FungibleTokenMetadataViews`| `0xee82856bf20e2aa6`    | `0x0000000000000002` |
+| `FungibleTokenSwitchboard`  | `0xee82856bf20e2aa6`    | `0x0000000000000002` |
 
 See the other guides in this section of the docs for the import
 addresses of other important contracts in the emulator.
@@ -68,10 +70,14 @@ addresses of other important contracts in the emulator.
 As for contracts that are important for NFT developers but aren't "core contracts",
 here is information about where to find the Cadence 1.0 Versions of Each:
 
-**USDC:** The USDC contract is still being updated for Cadence 1.0 and is currently not available.
+**USDC:** See [this PR in the USDC repo](https://github.com/flow-usdc/flow-usdc/pull/82)
+for updated USDC contracts.
 
-**Account Linking and Hybrid Custody:** The account linking and hybrid custody contracts
-are still being updated for Cadence 1.0 and are currently not available.
+**Account Linking and Hybrid Custody:** See [this PR in the hybrid custody repo](https://github.com/onflow/hybrid-custody/pull/164)
+for updated hybrid custody contracts.
+
+[This discord announcement](https://discord.com/channels/613813861610684416/811693600403357706/1225909248429527140)
+also contains versions of a lot of important contracts.
 
 For any other contracts, search for their github repo and there will likely be
 a PR or feature branch with the Cadence 1.0 changes. If there isn't, please
@@ -112,6 +118,7 @@ access(all) fun deposit(from: @{FungibleToken.Vault})
 **Note for Custom Migrations:** All stored objects that currently use the concrete type
 `FungibleToken.Vault` will be automatically migrated to use the interface type `{NonFungibleToken.Vault}`
 as part of the Flow team's custom state migrations.
+Your code still needs to be updated to reflect this though.
 
 ## Add `Withdraw` entitlements to `withdraw()`
 

--- a/versioned_docs/version-1.0/cadence-migration-guide/nft-guide.mdx
+++ b/versioned_docs/version-1.0/cadence-migration-guide/nft-guide.mdx
@@ -55,15 +55,17 @@ to be upgraded and migrated properly. You can find informaion about how to do th
 here: https://github.com/onflow/contract-updater
 
 Additionally, here are the import addresses
-for all of the important contracts related to non-fungible tokens:
+for all of the important contracts related to non-fungible tokens.
+The second column is the import address if you are testing with a basic version of the emulator.
+The third column contains the import addresses if you are using the Cadence testing framework.
 
-| Contract           | Emulator Import Address |
-| ------------------ | ----------------------- |
-| `NonFungibleToken` | `0xf8d6e0586b0a20c7`    |
-| `FungibleToken`    | `0xee82856bf20e2aa6`    |
-| `ViewResolver`     | `0xf8d6e0586b0a20c7`    |
-| `Burner`           | `0xf8d6e0586b0a20c7`    |
-| `MetadataViews`    | `0xf8d6e0586b0a20c7`    |
+| Contract           | Emulator Import Address | Testing Framework    |
+| ------------------ | ----------------------- | -------------------- |
+| `NonFungibleToken` | `0xf8d6e0586b0a20c7`    | `0x0000000000000001` |
+| `FungibleToken`    | `0xee82856bf20e2aa6`    | `0x0000000000000002` |
+| `ViewResolver`     | `0xf8d6e0586b0a20c7`    | `0x0000000000000001` |
+| `Burner`           | `0xf8d6e0586b0a20c7`    | `0x0000000000000001` |
+| `MetadataViews`    | `0xf8d6e0586b0a20c7`    | `0x0000000000000001` |
 
 See the other guides in this section of the docs for the import
 addresses of other important contracts in the emulator.
@@ -77,12 +79,16 @@ for the updated versions of NFT Catalog contracts.
 **NFT Storefront:** See [the `cadence-1.0` branch in the NFT Storefront Repo](https://github.com/onflow/nft-storefront/tree/cadence-1.0/contracts)
 for the updated versions of the `NFTStorefront` and `NFTStorefrontV2` contracts.
 
-**USDC:** The USDC contract is still being updated for Cadence 1.0 and is currently not available.
+**USDC:** See [this PR in the USDC repo](https://github.com/flow-usdc/flow-usdc/pull/82)
+for updated USDC contracts.
 
-**Account Linking and Hybrid Custody:** The account linking and hybrid custody contracts
-are still being updated for Cadence 1.0 and are currently not available.
+**Account Linking and Hybrid Custody:** See [this PR in the hybrid custody repo](https://github.com/onflow/hybrid-custody/pull/164)
+for updated hybrid custody contracts.
 
-For any other contracts, search for their github repo and there will likely be
+[This discord announcement](https://discord.com/channels/613813861610684416/811693600403357706/1225909248429527140)
+also contains versions of a lot of important contracts.
+
+For any others, search for their github repo and there will likely be
 a PR or feature branch with the Cadence 1.0 changes. If there isn't, please
 create an issue in the repo or reach out to that team directly via their support
 or Discord channel to ask them about their plans to update their contracts.
@@ -150,15 +156,15 @@ The improvements will be described here as they apply to specific changes
 that projects need to make in order to be ready for the upgrade,
 but it is good to read all sources to fully understand the changes.
 
-Please read the motivation section of the NFT-V2 FLIP to learn about
-why most of the changes to the standard were needed or desired.
+Please read the motivation section of [the NFT-V2 FLIP](https://github.com/onflow/flips/pull/56)
+to learn about why most of the changes to the standard were needed or desired.
 
 First, we will cover the changes that come from the new token standards and then
 we will cover the changes that come from Cadence.
 
 ### Previous Non-Permitted Changes
 
-Until now, there were a lot of restrictions on what changes are allowed
+Until now, there were many restrictions on what changes are allowed
 in upgrades to Cadence smart contracts, like not being allowed to change the type of fields,
 not being able to change interface conformance, and more.
 Many of the Cadence 1.0 changes require updates that break some of these rules,
@@ -196,7 +202,7 @@ currently, but there was a period of time when the new standards defined `NonFun
 as a contract instead of an interface, so anyone who was testing with those early versions
 should make sure that their contract still implements `NonFungibleToken`.
 This will ensure that the correct metadata view methods are enforced from `ViewResolver`
-and that your contract has the correct `createEmptyCollection()` method defined.
+and that your contract has the correct `createEmptyCollection(nftType: Type)` method defined.
 
 It is important to understand that the new `NonFungibleToken` no longer specifies types
 that you need to define like `NFT` and `Collection`. These were changed to interfaces
@@ -230,6 +236,7 @@ in order to be considered compatible with the standard!
 
 ```cadence
 access(all) contract ExampleNFT: NonFungibleToken {
+
     /// We choose the name NFT here, but this type can have any name now
     /// because the interface does not require it to have a specific name any more
     access(all) resource NFT: NonFungibleToken.NFT {
@@ -240,9 +247,20 @@ This will ensure that your `NFT` resource has all the correct fields and functio
 As part of this upgrade, you should remove the `NonFungibleToken.INFT` implementation specification
 from the declaration of your `NFT` because the `INFT` interface has been removed.
 
+In your code, any instance that refers
+to `@NonFungibleToken.NFT` or `&NonFungibleToken.NFT` need to be updated to
+`@{NonFungibleToken.NFT}` or `&{NonFungibleToken.NFT}` respectively.
+
+Example in `deposit()`:
+
+```cadence
+/// deposit now accepts a resource that implements the `NonFungibleToken.NFT` interface type
+access(all) fun deposit(token: @{NonFungibleToken.NFT})
+```
+
 **Note for Custom Migrations:** All stored objects that currently use the concrete type
 `NonFungibleToken.NFT` will be automatically migrated to use the interface type `{NonFungibleToken.NFT}`
-as part of the Flow team's custom state migrations.
+as part of the Flow team's custom state migrations. Your code still needs to be updated to reflect this though.
 
 ### Your Collection implements NonFungibleToken.Collection
 
@@ -254,9 +272,15 @@ so your `Collection` resource type needs to implement it in order to be conforma
 access(all) resource Collection: NonFungibleToken.Collection {
 ```
 
+In addition, since `Collection` is an interface, you will need to update every instance in your code
+that refers to `@NonFungibleToken.Collection` or `&NonFungibleToken.Collection` to
+`@{NonFungibleToken.Collection}` or `&{NonFungibleToken.Collection}` respectively to show
+that it is now an interface specification instead of a concrete type specification.
+
 **Note for Custom Migrations:** All stored objects that currently use the concrete type
 `NonFungibleToken.Collection` will be automatically migrated to use the interface type `{NonFungibleToken.Collection}`
-as part of the Flow team's custom state migrations.
+as part of the Flow team's custom state migrations. Your code still needs to be updated to reflect this though.
+
 
 ### Remove Project-Specific Events
 
@@ -302,7 +326,7 @@ For event listeners, the events will have this format:
 A.f8d6e0586b0a20c7.NonFungibleToken.Deposited(...)
 ```
 
-Where the address is whatever address the `NonFungibleToken` contract is deployed to.
+Where the address is whatever address the `NonFungibleToken` contract interface is deployed to.
 
 ### Implement ViewResolver
 
@@ -381,7 +405,7 @@ get an idea of the size of your collection.
 ```cadence
 /// Gets the amount of NFTs stored in the collection
     access(all) view fun getLength(): Int {
-        return self.ownedNFTs.keys.length
+        return self.ownedNFTs.length
     }
 ```
 
@@ -513,6 +537,13 @@ because it is extremely important for you to understand in order to build safe s
 Most contracts can update and `pub` access modifiers to **access(all)**,
 but there are some functions, such as `withdraw`, that need to have entitled access.
 
+These privledge functions need to have entitled access now because as part of Cadence 1.0,
+any restricted reference can be downcast to the concrete reference type without
+needing to be an authorized reference. This means for example, that a `&{NonFungibleToken.Receiver}`
+reference can be cast to a `&{NonFungibleToken.Collection}` reference, which would give
+access to the `withdraw()` method if it is `access(all)`! 
+You can read more about how references work in Cadence 1.0 [here](https://cadence-lang.org/docs/1.0/language/references).
+
 A good rule to follow is that if there is a resource that will ever have a reference
 created for it (such as for a public or private capability), any functions that
 you don't want everyone in the network to be able to have access to should be
@@ -546,24 +577,8 @@ self.withdrawRef = signer.storage.borrow<auth(NonFungibleToken.Withdraw) &{NonFu
 
 From the [flow-nft `transfer_nft.cdc` transaction](https://github.com/onflow/flow-nft/blob/standard-v2/transactions/transfer_nft.cdc).
 
-In addition, since `Collection` is an interface, you will need to update every instance in your code
-that refers to `@NonFungibleToken.Collection` or `&NonFungibleToken.Collection` to
-`@{NonFungibleToken.Collection}` or `&{NonFungibleToken.Collection}` respectively to show
-that it is now an interface specification instead of a concrete type specification.
-
-This also applies to `NonFungibleToken.NFT`. Any instance that refers
-to `@NonFungibleToken.NFT` or `&NonFungibleToken.NFT` need to be updated to
-`@{NonFungibleToken.NFT}` or `&{NonFungibleToken.NFT}` respectively.
-
-Example in `deposit()`:
-
-```cadence
-/// deposit now accepts a resource that implements the `NonFungibleToken.NFT` interface type
-access(all) fun deposit(token: @{NonFungibleToken.NFT})
-```
-
 **Note on Custom State Migrations:** You may be wondering
-how you can get these entitlements onto capabilities
+how you can get these entitlements onto `Provider` capabilities
 that already exist in a contract or in an account. As part of the automatic
 migrations, all existing capabilities will be automatically migrated to
 use a type that offers the same level of access. In the case of Capabilities

--- a/versioned_docs/version-1.0/design-patterns.md
+++ b/versioned_docs/version-1.0/design-patterns.md
@@ -447,23 +447,6 @@ This means providers should only publish capabilities to recipients they trust t
 or limit the type with which the capability is authorized in order to only give recipients access to the functionality
 that the provider is willing to allow them to copy.
 
-
-## Capability revocation
-
-### Problem
-
-A capability provided by one account to a second account must able to be revoked
-by the first account without the co-operation of the second.
-
-### Solution
-
-The first account should issue a _new_ capability
-and use it only for the purpose of granting the second account access.
-
-Once the first account wants to revoke access to the resource in storage,
-they can simply get the capability controller for that capability and delete it.
-
-
 ## Check for existing capability before publishing new one
 
 ### Problem

--- a/versioned_docs/version-1.0/project-development-tips.md
+++ b/versioned_docs/version-1.0/project-development-tips.md
@@ -38,8 +38,7 @@ and more vibrant community.
 
 Ensuring appropriate levels of testing results in better smart contracts which have
 pro-actively modeled threats and engineered against them. Ensuring appropriate levels 
-of standards adoption ([FungibleToken](https://github.com/onflow/flow-ft),
-[NFT Catalog](https://www.flow-nft-catalog.com/), [NFT StoreFront](https://github.com/onflow/nft-storefront), etc) by dapp 
+of standards adoption ([FungibleToken](https://github.com/onflow/flow-ft), [NFT StoreFront](https://github.com/onflow/nft-storefront), etc) by dapp 
 builders amplifies the network effects for all in the ecosystem. NFTs in one dapp can be 
 readily consumed by other dapps through on-chain events with no new integration 
 required. With your help and participation we can further accelerate healthy and vibrant 
@@ -106,13 +105,13 @@ is not available or leaves the project. It is important that there are others wh
 can fill in who have a clear understanding of the code and requirements so they can give good feedback,
 perform effective reviews, and make changes where needed.
 
-### Projects should maintain a well-organized open source Repo for their smart contracts
+### Projects should maintain a well-organized open source repository for their smart contracts
 
 As projects like NBA Topshot have shown, when a blockchain product becomes successful
 others can and do to build on top of what you are doing.
 Whether that is analytics, tools, or other value adds that could help grow your project ecosystem,
 composability is key and that depends on open source development.
-If there isn’t already an open source repo, builders should consider creating one.
+If there isn’t already an open source repo, builders should strongly consider creating one.
 
 Builders can start from the [the Flow open source template](https://github.com/onflow/open-source-template)
 and make sure all of their repo is set up with some initial documentation for what the repo is for
@@ -172,24 +171,20 @@ Summarized below is a list of testing related recommendations
 which are noteworthy to mention for a typical smart contract project.
 
 Popular testing frameworks to use for cadence are listed here:
+Cadence: [Cadence Testing Framework](./testing-framework.mdx)
 Javascript: [Flow JS Testing](https://developers.flow.com/tools/flow-js-testing/index.md)
 Go: [Overflow](https://github.com/bjartek/overflow)
-Cadence: [Cadence Testing Framework](https://github.com/onflow/cadence/blob/ac05b6a0d6005cde468573f0a7a2e3a67f49bd90/docs/testing-framework.mdx)
-Tests written in Cadence!
 
 The same person who writes the code should also write the tests.
 They have the clearest understanding of the code paths and edge cases.
-
 
 Tests should be **mandatory**, not optional, even if the contract is copied from somewhere else.
 There should be thorough emulator unit tests in the public repo.
 [See the flow fungible token repo](https://github.com/onflow/flow-ft/tree/master/tests)
 for an example of unit tests in cadence.
 
-
 Every time there is a new Cadence version or emulator version,
 the dependencies of the repo should be updated to make sure the tests are all still passing.
-
 
 Tests should avoid being monolithic;
 Individual test cases should be set up for each part of the contract to test them in isolation. 
@@ -245,7 +240,7 @@ with detailed and useful comments within contracts, transactions, and scripts.
 The more that a project can be understood, that it adheres to standards,
 and can be built upon with ease, the more likely others will build against it in turn. 
 
-Each project should have a detailed README.md with these sections:
+Each project should have a detailed `README.md` with these sections:
     - Explanation of the project itself with links to the app
     - Addresses on various networks
     - High-level technical description of the contracts with emphasis on important types and functionality
@@ -298,5 +293,4 @@ Composability and extensibility should also be priorities while designing, devel
 and documenting their projects. (Documentation for these topics coming soon)
 
 
-
-If you have any feedback about these guidelines, please create an issue in the onflow/cadence-style-guide repo or make a PR updating the guidelines so we can start a discussion.
+If you have any feedback about these guidelines, please create an issue in the `onflow/cadence-style-guide` repo or make a PR updating the guidelines so we can start a discussion.

--- a/versioned_docs/version-1.0/project-development-tips.md
+++ b/versioned_docs/version-1.0/project-development-tips.md
@@ -293,4 +293,4 @@ Composability and extensibility should also be priorities while designing, devel
 and documenting their projects. (Documentation for these topics coming soon)
 
 
-If you have any feedback about these guidelines, please create an issue in the `onflow/cadence-style-guide` repo or make a PR updating the guidelines so we can start a discussion.
+If you have any feedback about these guidelines, please create an issue in the `cadence-lang.org` repo or make a PR updating the guidelines so we can start a discussion.


### PR DESCRIPTION
I went through the cadence docs that I manage (except the tutorials) and made sure they made sense with the current versions of the core contracts and my understanding. Also fixed some wording and added import addresses for the testing framework