### PR TITLE
fix broken links in Proof of Possession paragraph on the crypto page

### DIFF
--- a/docs/language/crypto.mdx
+++ b/docs/language/crypto.mdx
@@ -256,9 +256,9 @@ These tools are defined in the built-in `BLS` contract, which does not need to b
 Multi-signature verification in BLS requires a defense against rogue public-key attacks. Multiple ways are
 available to protect BLS verification. Cadence provides the proof of possession of private key as a defense tool.
 The proof of possession of private key is a BLS signature over the public key itself.
-The PoP signature follows the same requirements of a BLS signature (detailed in [Signature verification](#Signature-verification)),
+The PoP signature follows the same requirements of a BLS signature (detailed in [Signature verification](#signature-verification)),
 except it uses a special domain separation tag. The key expected to be used in KMAC128 is the UTF-8 encoding of `"BLS_POP_BLS12381G1_XOF:KMAC128_SSWU_RO_POP_"`.
-The expected message to be signed by the PoP is the serialization of the BLS public key corresponding to the signing private key ([serialization details](#PublicKey)).
+The expected message to be signed by the PoP is the serialization of the BLS public key corresponding to the signing private key ([serialization details](#public-key-construction)).
 The PoP can only be verified using the `PublicKey` method `verifyPoP`.
 
 ### BLS signature aggregation

--- a/versioned_docs/version-1.0/language/crypto.mdx
+++ b/versioned_docs/version-1.0/language/crypto.mdx
@@ -291,9 +291,9 @@ These tools are defined in the built-in `BLS` contract, which does not need to b
 Multi-signature verification in BLS requires a defense against rogue public-key attacks. Multiple ways are
 available to protect BLS verification. Cadence provides the proof of possession of private key as a defense tool.
 The proof of possession of private key is a BLS signature over the public key itself.
-The PoP signature follows the same requirements of a BLS signature (detailed in [Signature verification](#Signature-verification)),
+The PoP signature follows the same requirements of a BLS signature (detailed in [Signature verification](#signature-verification)),
 except it uses a special domain separation tag. The key expected to be used in KMAC128 is the UTF-8 encoding of `"BLS_POP_BLS12381G1_XOF:KMAC128_SSWU_RO_POP_"`.
-The expected message to be signed by the PoP is the serialization of the BLS public key corresponding to the signing private key ([serialization details](#public-keys)).
+The expected message to be signed by the PoP is the serialization of the BLS public key corresponding to the signing private key ([serialization details](#public-key-construction)).
 The PoP can only be verified using the `PublicKey` method `verifyPoP`.
 
 ### BLS signature aggregation


### PR DESCRIPTION
links in the section [Proof of Possession](https://cadence-lang.org/docs/language/crypto#proof-of-possession-pop) on the `language/crypto` doc site are broken (screenshot below, broken links coloured in green). 


Regarding `Signature verification`:
The problem is simply a typo, where the "S" in the link should _not_ be capitalized. The link should be:
```
https://cadence-lang.org/docs/language/crypto#signature-verification 
```

Regarding `serialization details`:
I am not entirely sure where the link should point to. The [PublicKey](https://cadence-lang.org/docs/language/crypto#publickey) section is pretty long. I would suggest to link directly to the sub-section [Public Key construction](https://cadence-lang.org/docs/language/crypto#public-key-construction):
```
https://cadence-lang.org/docs/language/crypto#public-key-construction
```
---- 
**screenshot**:
<img width="907" alt="Screenshot 2024-07-05 at 2 18 30 PM" src="https://github.com/onflow/cadence-lang.org/assets/26322303/3f0e1fea-ac25-436b-a3f1-d7d84e1c222d">
