### PR TITLE
Replace links for first 4 tutorials and update import addresses

### DIFF
--- a/docs/tutorial/01-first-steps.md
+++ b/docs/tutorial/01-first-steps.md
@@ -33,11 +33,6 @@ deploy them to a local Flow emulated blockchain, and submit transactions.
 The Flow Playground should work with any standard web browser.
 However, we recommend using Google Chrome, as it has been primarily tested and optimized for this browser.
 
-The [Flow Crescendo (Cadence 1.0) upgrade](https://flow.com/upgrade/crescendo)
-introduces new and powerful features to Cadence. Currently, the playground uses an older version
-of Cadence, but you can interact with a Cadence 1.0 playground by going to
-https://v1.play.flow.com/.
-
 ## Getting to know the Playground
 
 The Playground contains everything you need to get familiar

--- a/docs/tutorial/02-hello-world.md
+++ b/docs/tutorial/02-hello-world.md
@@ -3,7 +3,7 @@ archived: false
 draft: false
 title: 2. Hello World
 description: A smart contract tutorial for Cadence.
-date: 2024-06-05
+date: 2024-09-05
 meta:
   keywords:
     - tutorial
@@ -23,21 +23,12 @@ In this tutorial, we'll write and deploy our first smart contract!
 <Callout type="success">
   Open the starter code for this tutorial in the Flow Playground: <br />
   <a
-    href="https://play.onflow.org/af7aba31-dee9-4477-9e1d-7b46e958468e"
+    href="https://play.flow.com/483b2f33-9e71-40aa-924a-2c5f0ead77aa"
     target="_blank"
   >
-    https://play.onflow.org/af7aba31-dee9-4477-9e1d-7b46e958468e
+    https://play.flow.com/483b2f33-9e71-40aa-924a-2c5f0ead77aa
   </a>
   The tutorial will ask you to take various actions to interact with this code.
-</Callout>
-
-<Callout type="info">
-  The playground code that is linked uses Cadence 0.42, but the examples
-  use Cadence 1.0 to show how each contract, transaction and script
-  is implemented in Cadence 1.0. 
-  You can access a Cadence 1.0-compatible playground by going to https://v1.play.flow.com/.
-  The project link will still work with the current version of the playground,
-  but when the playground is updated to Cadence 1.0, the link will be replaced with a 1.0-compatible version.
 </Callout>
 
 <Callout type="info">
@@ -71,7 +62,7 @@ which will open up the contracts that are saved for that account.
 The `HelloWorld` contracts are loaded by default for each account
 unless you load an existing playground project with other saved contracts.
 
-For this tutorial, you'll be working with only the first account `0x01`
+For this tutorial, you'll be working with only the first account `0x06`
 
 ## Implementing Hello World
 
@@ -101,10 +92,10 @@ If you haven't already, you'll need to follow this link to open a playground ses
 
 {' '}
 <a
-  href="https://play.onflow.org/dbc06b40-d0b1-42da-9e0d-686bc9972e65"
+  href="https://play.flow.com/483b2f33-9e71-40aa-924a-2c5f0ead77aa"
   target="_blank"
 >
-  https://play.onflow.org/dbc06b40-d0b1-42da-9e0d-686bc9972e65
+  https://play.flow.com/483b2f33-9e71-40aa-924a-2c5f0ead77aa
 </a>
 
 </Callout>
@@ -113,7 +104,7 @@ If you haven't already, you'll need to follow this link to open a playground ses
 
 <Callout type="info">
 
-Open the Account `0x01` tab with the file called
+Open the Account `0x06` tab with the file called
 `HelloWorld.cdc` in the Contract 1 space. <br />
 `HelloWorld.cdc` should contain this code:
 
@@ -122,14 +113,12 @@ Open the Account `0x01` tab with the file called
 ```cadence HelloWorld.cdc
 // HelloWorld.cdc
 //
-access(all)
-contract HelloWorld {
+access(all) contract HelloWorld {
 
     // Declare a public (access(all)) field of type String.
     //
     // All fields must be initialized in the initializer.
-    access(all)
-    let greeting: String
+    access(all) let greeting: String
 
     // The initializer is required if the contract contains any fields.
     init() {
@@ -137,8 +126,7 @@ contract HelloWorld {
     }
 
     // Public function that returns our friendly greeting!
-    access(all) view
-    fun hello(): String {
+    access(all) view fun hello(): String {
         return self.greeting
     }
 }
@@ -194,7 +182,7 @@ An account is divided into two main areas:
    for controlling how these stored objects can be accessed.
    We'll cover account storage and capabilities in more detail in a later tutorial.
 
-In this tutorial, we use the account with the address `0x01` to store our `HelloWorld` contract.
+In this tutorial, we use the account with the address `0x06` to store our `HelloWorld` contract.
 
 ### Deploying Code
 
@@ -204,9 +192,9 @@ Now that you know what an account is in a Cadence context, you can deploy the `H
 
 <Callout type="info">
 
-Make sure that the account `0x01` tab is selected and that the
+Make sure that the account `0x06` tab is selected and that the
 `HelloWorld.cdc` file is in the editor. <br />
-Click the deploy button to deploy the contents of the editor to account `0x01`.
+Click the deploy button to deploy the contents of the editor to account `0x06`.
 
 </Callout>
 
@@ -214,7 +202,7 @@ Click the deploy button to deploy the contents of the editor to account `0x01`.
 
 You should see a log in the output area indicating that the deployment succeeded.
 
-    `Deployed Contract To: 0x01`
+    `Deployed Contract To: 0x06`
 
 You'll also see the name of the contract show up in the selected account tab underneath the number for the account.
 This indicates that the `HelloWorld` contract has been deployed to the account.
@@ -243,7 +231,7 @@ Open the transaction named `Simple Transaction` <br />
 </Callout>
 
 ```cadence SayHello.cdc
-import HelloWorld from 0x01
+import HelloWorld from 0x06
 
 transaction {
 
@@ -253,13 +241,12 @@ transaction {
     log(HelloWorld.hello())
   }
 }
-
 ```
 
-This transaction first imports our `HelloWorld` smart contract from the account `0x01`.
+This transaction first imports our `HelloWorld` smart contract from the account `0x06`.
 If you haven't deployed the smart contract from the account, the transaction won't have access to it and the import will fail.
 This imports the entire contract code from `HelloWorld`, including type definitions and public functions,
-so that the transaction can use them to interact with the `HelloWorld` contract in account `0x01`.
+so that the transaction can use them to interact with the `HelloWorld` contract in account `0x06`.
 
 To import a smart contract from any other account, type this line at the top of your transaction:
 
@@ -281,7 +268,7 @@ Transactions are divided into two main phases, `prepare` and `execute`.
 
 <Callout type="info">
 
-In the box at the bottom right of the editor, select Account `0x01` as the transaction signer. <br />
+In the box at the bottom right of the editor, select Account `0x06` as the transaction signer. <br />
 Click the `Send` button to submit the transaction
 
 </Callout>
@@ -292,7 +279,7 @@ You should see something like this in the transaction results at the bottom of t
 Simple Transaction "Hello, World!"
 ```
 
-Congratulations, you just executed your first Cadence transaction with the account `0x01` as the signer.
+Congratulations, you just executed your first Cadence transaction with the account `0x06` as the signer.
 
 In this tutorial, you'll get the same result if you use different signers for the transaction
 but later tutorials will use more complex examples that have different results depending on the signer.
@@ -303,7 +290,7 @@ This tutorial covered an introduction to Cadence, including terms like accounts,
 We implemented a smart contract that is accessible in all scopes.
 The smart contract had a `String` field initialized with the value `Hello, World!` and a function to return (read) this value.
 Next, we deployed this contract in an account and implemented a transaction to call the function in the smart contract and log the result to the console.
-Finally, we used the account `0x01` as the signer for this transaction.
+Finally, we used the account `0x06` as the signer for this transaction.
 
 Now that you have completed the tutorial, you have the basic knowledge to write a simple Cadence program that can:
 

--- a/docs/tutorial/02-hello-world.md
+++ b/docs/tutorial/02-hello-world.md
@@ -3,7 +3,7 @@ archived: false
 draft: false
 title: 2. Hello World
 description: A smart contract tutorial for Cadence.
-date: 2024-09-05
+date: 2024-09-17
 meta:
   keywords:
     - tutorial

--- a/docs/tutorial/03-resources.md
+++ b/docs/tutorial/03-resources.md
@@ -3,7 +3,7 @@ archived: false
 draft: false
 title: 3. Resource Contract Tutorial
 description: An introduction to resources, capabilities, and account storage in Cadence
-date: 2024-09-05
+date: 2024-09-17
 meta:
   keywords:
     - tutorial

--- a/docs/tutorial/03-resources.md
+++ b/docs/tutorial/03-resources.md
@@ -3,7 +3,7 @@ archived: false
 draft: false
 title: 3. Resource Contract Tutorial
 description: An introduction to resources, capabilities, and account storage in Cadence
-date: 2024-06-05
+date: 2024-09-05
 meta:
   keywords:
     - tutorial
@@ -24,21 +24,12 @@ socialImageDescription: Resource smart contract image.
 <Callout type="success">
   Open the starter code for this tutorial in the Flow Playground: <br />
   <a
-    href="https://play.onflow.org/b70199ae-6488-4e58-ae58-9f4ffecbd66a"
+    href="https://play.flow.com/ddf0177e-81c8-4512-ac2e-28036b1a3f89"
     target="_blank"
   >
-    https://play.onflow.org/b70199ae-6488-4e58-ae58-9f4ffecbd66a
+    https://play.flow.com/ddf0177e-81c8-4512-ac2e-28036b1a3f89
   </a>
   The tutorial will ask you to take various actions to interact with this code.
-</Callout>
-
-<Callout type="info">
-  The playground code that is linked uses Cadence 0.42, but the examples
-  use Cadence 1.0 to show how each contract, transaction and script
-  is implemented in Cadence 1.0. 
-  You can access a Cadence 1.0-compatible playground by going to https://v1.play.flow.com/.
-  The project link will still work with the current version of the playground,
-  but when the playground is updated to Cadence 1.0, the link will be replaced with a 1.0-compatible version.
 </Callout>
 
 <Callout type="info">
@@ -65,8 +56,7 @@ but with some special rules.
 
 Here is an example definition of a resource:
 ```cadence
-access(all)
-resource Money {
+access(all) resource Money {
   
   access(all) let balance: Int
 
@@ -120,31 +110,27 @@ that any given resource only exists in one place at a time.
 
 <Callout type="info">
 
-Open the Account `0x01` tab with file named `HelloWorldResource.cdc`. <br />
+Open the Account `0x06` tab with file named `HelloWorldResource.cdc`. <br />
 `HelloWorldResource.cdc` should contain the following code:
 
 </Callout>
 
 ```cadence HelloWorldResource.cdc
-access(all)
-contract HelloWorld {
+access(all) contract HelloWorld {
 
     // Declare a resource that only includes one function.
-    access(all)
-    resource HelloAsset {
+    access(all) resource HelloAsset {
 
         // A transaction can call this function to get the "Hello, World!"
         // message from the resource.
-        access(all)
-        view fun hello(): String {
+        access(all) view fun hello(): String {
             return "Hello, World!"
         }
     }
 
     // We're going to use the built-in create function to create a new instance
     // of the HelloAsset resource
-    access(all)
-    fun createHelloAsset(): @HelloAsset {
+    access(all) fun createHelloAsset(): @HelloAsset {
         return <-create HelloAsset()
     }
 }
@@ -152,11 +138,11 @@ contract HelloWorld {
 
 <Callout type="info">
 
-Deploy this code to account `0x01` using the `Deploy` button.
+Deploy this code to account `0x06` using the `Deploy` button.
 
 </Callout>
 
-We start by declaring a new `HelloWorld` contract in account `0x01`, inside this new `HelloWorld` contract we:
+We start by declaring a new `HelloWorld` contract in account `0x06`, inside this new `HelloWorld` contract we:
 
 1. Declare the resource `HelloAsset` with public scope `access(all)`
 2. Declare the resource function `hello()` inside `HelloAsset` with public scope `access(all)`
@@ -259,20 +245,22 @@ Open the transaction named `Create Hello`.
 </Callout>
 
 ```cadence create_hello.cdc
-// create_hello.cdc
-// This transaction calls the createHelloAsset() function from the contract
-// to create a resource, then saves the resource in account storage using the "save" method.
-import HelloWorld from 0x01
+/// create_hello.cdc
+/// This transaction calls the createHelloAsset() function from the contract
+/// to create a resource, then saves the resource
+/// in the signer's account storage using the "save" method.
+import HelloWorld from 0x06
 
 transaction {
 
-  /// `auth(SaveValue) &Account` means that it is an account object
-  /// that has the `SaveValue` authorization entitlement, which means
-  /// that this transaction can't do anything with the &Account object
-  /// besides saving values to storage.
+    /// `auth(SaveValue) &Account` signifies an account object
+    /// that has the `SaveValue` authorization entitlement, which means
+    /// that this transaction can't do anything with the &Account object
+    /// besides saving values to storage.
+    /// You will learn more about entitlements later
 	prepare(acct: auth(SaveValue) &Account) {
         // Here we create a resource and move it to the variable newHello,
-        // then we save it in the account storage
+        // then we save it in the signer's account storage
         let newHello <- HelloWorld.createHelloAsset()
 
         acct.storage.save(<-newHello, to: /storage/HelloAssetTutorial)
@@ -287,7 +275,7 @@ transaction {
 
 Here's what this transaction does:
 
-1. Import the `HelloWorld` definitions from account `0x01`
+1. Import the `HelloWorld` definitions from account `0x06`
 2. Uses the `createHelloAsset()` function to create a resource and move it to `newHello`
 3. `save` the created resource in the account storage of the account
    that signed the transaction at the path `/storage/HelloAssetTutorial`
@@ -362,7 +350,7 @@ log("Saved Hello Resource to account.")
 
 <Callout type="info">
 
-Select account `0x01` as the only signer. Click the `Send` button to submit
+Select account `0x06` as the only signer. Click the `Send` button to submit
 the transaction.
 
 </Callout>
@@ -391,8 +379,8 @@ so we know that the storage spot at `/storage/HelloAssetTutorial` is empty.
 In real applications, we would likely perform necessary checks and actions with the location path we are storing in
 to make sure we don't abort a transaction because of an accidental overwrite.
 
-Now that you have executed the transaction, account `0x01` should have the newly created `HelloWorld.HelloAsset`
-resource stored in its storage. You can verify this by clicking on account `0x01` on the bottom left.
+Now that you have executed the transaction, account `0x06` should have the newly created `HelloWorld.HelloAsset`
+resource stored in its storage. You can verify this by clicking on account `0x06` on the bottom left.
 This should open a view of the different contracts and objects in the account.
 You should see this entry for the `HelloWorld` contract and the `HelloAsset` resource:
 
@@ -451,22 +439,23 @@ Open the transaction named `Load Hello`.
 </Callout>
 
 ```cadence load_hello.cdc
-import HelloWorld from 0x01
+import HelloWorld from 0x06
 
 // This transaction calls the "hello" method on the HelloAsset object
 // that is stored in the account's storage by removing that object
-// from storage, calling the method, and then putting it back in storage
+// from storage, calling the method, and then saving it back to the same storage path
 
 transaction {
 
     /// In this prepare block, we have to load a value from storage
-    /// in addition to saving it, so we also need the `LoadValue` authorization entitlement
+    /// in addition to saving it, so we also need the `LoadValue` entitlement
+    /// which additionally allows loading values from storage 
     prepare(acct: auth(LoadValue, SaveValue) &Account) {
 
         // Load the resource from storage, specifying the type to load it as
         // and the path where it is stored
         let helloResource <- acct.storage.load<@HelloWorld.HelloAsset>(from: /storage/HelloAssetTutorial)
-          ?? panic("The signer does not have the HelloAsset resource stored at /storage/HelloAssetTutorial")
+            ?? panic("The signer does not have the HelloAsset resource stored at /storage/HelloAssetTutorial. Run the `Create Hello` Transaction again to store the resource")
 
         // log the hello world message
         log(helloResource.hello())
@@ -479,7 +468,7 @@ transaction {
 
 Here's what this transaction does:
 
-1. Import the `HelloWorld` definitions from account `0x01`
+1. Import the `HelloWorld` definitions from account `0x06`
 2. Moves the `HelloAsset` object from storage to `helloResource` with the move operator
   and the `load` function from the [account storage API](../language/accounts/storage.mdx)
 3. Calls the `hello()` function of the `HelloAsset` resource stored in `helloResource` and logs the result
@@ -489,6 +478,9 @@ We're going to be using the `prepare` phase again to load the resource
 using the [reference to the account](../language/accounts/index.mdx) that is passed in.
 
 Let's go over the transaction in more detail.
+
+#### Loads the `HelloAsset` resource from storage
+
 To remove an object from storage, we use the `load` method from the [account storage API](../language/accounts/storage.mdx)
 
 ```cadence
@@ -523,17 +515,41 @@ Here, we explicitly have to account for the possibility that the `helloResource`
 
 We use the nil-coalescing operator (`??`) to "unwrap" the optional.
 This basically means that we are handling the case where the `load` method returns `nil`.
-If it returns `nil`. We `panic`, which will abort execution of the transaction
-with an error message. It is important for developers to always provide detailed error messages
-so that if something goes wrong in the code, it is obvious what needs to be fixed.
+If it returns `nil`, the block of code after `??` executes.
+Here, we `panic`, which will abort execution of the transaction
+with an error message. 
 
 Refer to [Optionals In Cadence](../language/values-and-types.mdx#optionals) to learn more about optionals and how they are used.
+
+It is **extremely important** for developers to always provide detailed error messages
+so that if something goes wrong in the code, it is obvious to a user and/or developer
+what needs to be fixed.
+
+Error messages should contain these if possible:
+* Contract name and function name if coming from a contract.
+* Description of the literal error that is happening.
+* Description of what high-level reason might be causing the error.
+* Any metadata or variable values that might are relevant to the error.
+* Suggestion for fixing it if possible.
+
+As you can see in our error message, we describe exactly what is wrong,
+that the resource is not stored at the correct storage path (which we mention).
+Then we suggest a solution to remedy the error, that being to run the "Create Hello"
+transaction to store the resource.
+
+Check out the error messages in the [contracts](https://github.com/onflow/flow-nft/blob/master/contracts/NonFungibleToken.cdc#L115-L121)
+and [transactions](https://github.com/onflow/flow-nft/blob/master/transactions/generic_transfer_with_address_and_type.cdc#L46-L50)
+in the Flow NFT github repo for examples of thorough and helpful error messages.
+
+#### Calls the `hello()` function
 
 Next, we call the `hello()` function and log the output.
 
 ```cadence
 log(helloResource.hello())
 ```
+
+#### Saves the resource back in the signer's account
 
 Next, we use `save` again to put the object back in storage in the same spot:
 
@@ -543,7 +559,7 @@ acct.storage.save(<-helloResource, to: /storage/HelloAssetTutorial)
 
 <Callout type="info">
 
-Select account `0x01` as the only signer. Click the `Send` button to submit
+Select account `0x06` as the only signer. Click the `Send` button to submit
 the transaction.
 
 </Callout>
@@ -565,7 +581,7 @@ that returns the string `"Hello, World!"`
 and declared a function that can create a resource.
 
 Next, you deployed this contract in an account and implemented a transaction to create the resource in the smart contract
-and save it in the account `0x01` by using it as the signer for this transaction.
+and save it in the account `0x06` by using it as the signer for this transaction.
 
 Finally, you used a transaction to move the `HelloAsset` resource from account storage, call the `hello` method,
 and return it to the account storage.

--- a/docs/tutorial/04-capabilities.md
+++ b/docs/tutorial/04-capabilities.md
@@ -3,7 +3,7 @@ archived: false
 draft: false
 title: 4. Capability Tutorial
 description: An introduction to capabilities and how they interact with resources in Cadence
-date: 2024-09-05
+date: 2024-09-17
 meta:
   keywords:
     - tutorial

--- a/docs/tutorial/05-non-fungible-tokens-1.md
+++ b/docs/tutorial/05-non-fungible-tokens-1.md
@@ -3,7 +3,7 @@ archived: false
 draft: false
 title: 5.1 Non-Fungible Token Tutorial Part 1
 description: An introduction to NFTs on Cadence
-date: 2024-06-05
+date: 2024-09-17
 meta:
   keywords:
     - tutorial
@@ -31,20 +31,11 @@ In this tutorial, we're going to deploy, store, and transfer **Non-Fungible Toke
 
 Open the starter code for this tutorial in the Flow Playground:
 
-<a href="https://play.onflow.org/a21087ad-b22c-4981-b49e-17297e916fa6"
+<a href="https://play.flow.com/dde1e2a4-aae6-4eda-86fd-f0b0b3f53f7e"
   target="_blank">
-  https://play.onflow.org/a21087ad-b22c-4981-b49e-17297e916fa6
+  https://play.flow.com/dde1e2a4-aae6-4eda-86fd-f0b0b3f53f7e
 </a>
 The tutorial will ask you to take various actions to interact with this code.
-</Callout>
-
-<Callout type="info">
-  The playground code that is linked uses Cadence 0.42, but the examples
-  use Cadence 1.0 to show how each contract, transaction and script
-  is implemented in Cadence 1.0. 
-  You can access a Cadence 1.0-compatible playground by going to https://v1.play.flow.com/.
-  The project link will still work with the current version of the playground,
-  but when the playground is updated to Cadence 1.0, the link will be replaced with a 1.0-compatible version.
 </Callout>
 
 <Callout type="info">
@@ -165,15 +156,15 @@ to save NFTs in the account.
 First, you'll need to follow this link to open a playground session
 with the Non-Fungible Token contracts, transactions, and scripts pre-loaded:
 
-<a href="https://play.onflow.org/ae2f2a83-6698-4e03-93cf-70d35627e28e" target="_blank">
-  https://play.onflow.org/ae2f2a83-6698-4e03-93cf-70d35627e28e
+<a href="https://play.flow.com/dde1e2a4-aae6-4eda-86fd-f0b0b3f53f7e" target="_blank">
+  https://play.flow.com/dde1e2a4-aae6-4eda-86fd-f0b0b3f53f7e
 </a>
 
 </Callout>
 
 <Callout type="info">
 
-Open Account `0x01` to see `BasicNFT.cdc`.
+Open Account `0x06` to see `BasicNFT.cdc`.
 `BasicNFT.cdc` should contain the following code:
 
 </Callout>
@@ -259,13 +250,13 @@ You should now have an NFT in your account. Let's run a transaction to check.
 
 <Callout type="info">
 
-Open the `NFT Exists` transaction, select account `0x01` as the only signer, and send the transaction.<br/>
+Open the `NFT Exists` transaction, select account `0x06` as the only signer, and send the transaction.<br/>
 `NFT Exists` should look like this:
 
 </Callout>
 
 ```cadence NFTExists.cdc
-import BasicNFT from 0x01
+import BasicNFT from 0x06
 
 // This transaction checks if an NFT exists in the storage of the given account
 // by trying to borrow from it. If the borrow succeeds (returns a non-nil value), the token exists!
@@ -304,7 +295,7 @@ Open the `Basic Transfer` transaction.<br/>
 </Callout>
 
 ```cadence
-import BasicNFT from 0x01
+import BasicNFT from 0x06
 
 /// Basic transaction for two accounts to authorize
 /// to transfer an NFT
@@ -350,7 +341,7 @@ You can also scroll down a bit to see the correct code:
 Here is the correct code to load the NFT from one account and save it to another account.
 
 ```cadence
-import BasicNFT from 0x01
+import BasicNFT from 0x06
 
 /// Basic transaction for two accounts to authorize
 /// to transfer an NFT
@@ -374,14 +365,14 @@ transaction {
 
 <Callout type="info">
 
-Select both Account `0x01` and Account `0x02` as the signers.
-Make sure account `0x01` is the first signer.<br/>
+Select both Account `0x06` and Account `0x07` as the signers.
+Make sure account `0x06` is the first signer.<br/>
 Click the "Send" button to send the transaction.
 
 </Callout>
 
-Now, the NFT should be stored in the storage of Account `0x02`!
-You should be able to run the "NFT Exists" transaction again with `0x02` as the signer
+Now, the NFT should be stored in the storage of Account `0x07`!
+You should be able to run the "NFT Exists" transaction again with `0x07` as the signer
 to confirm that it is in their account.
 
 ## Enhancing the NFT Experience

--- a/docs/tutorial/05-non-fungible-tokens-2.md
+++ b/docs/tutorial/05-non-fungible-tokens-2.md
@@ -111,7 +111,7 @@ Instead, we can use a powerful feature of Cadence, resources owning other resour
 We'll define a new `Collection` resource as our NFT storage place
 to enable more-sophisticated ways to interact with our NFTs.
 
-The next contract we look at is called `ExampleNFT`, it's stored in Contract 1 in account `0x01`.
+The next contract we look at is called `ExampleNFT`, it's stored in Contract 1 in account `0x06`.
 
 This contract expands on the `BasicNFT` we looked at by adding:
 1. An `idCount` contract field that tracks unique NFT ids.
@@ -131,7 +131,7 @@ concepts this contract introduces.
 
 <Callout type="info">
 
-Open Account `0x01` to see `ExampleNFT.cdc`.<br/>
+Open Account `0x06` to see `ExampleNFT.cdc`.<br/>
 Deploy the contract by clicking the Deploy button in the bottom right of the editor.<br/>
 `ExampleNFT.cdc` should contain the code below.
 It contains what was already in `BasicNFT.cdc` plus additional resource declarations in the contract body.
@@ -420,18 +420,18 @@ Scripts in Cadence are simple transactions that run without any account permissi
 
 <Callout type="info">
 
-Open the script file named `Print 0x01 NFTs`.
-`Print 0x01 NFTs` should contain the following code:
+Open the script file named `Print 0x06 NFTs`.
+`Print 0x06 NFTs` should contain the following code:
 
 </Callout>
 
 ```cadence
-import ExampleNFT from 0x01
+import ExampleNFT from 0x06
 
-// Print the NFTs owned by account 0x01.
+// Print the NFTs owned by account 0x06.
 access(all) fun main(): [UInt64] {
-    // Get the public account object for account 0x01
-    let nftOwner = getAccount(0x01)
+    // Get the public account object for account 0x06
+    let nftOwner = getAccount(0x06)
 
     // Find the public Receiver capability for their Collection and borrow it
     let receiverRef = nftOwner.capabilities
@@ -446,20 +446,20 @@ access(all) fun main(): [UInt64] {
 
 <Callout type="info">
 
-Execute `Print 0x01 NFTs` by clicking the Execute button in the top right of the editor box.<br/>
-This script returns a list of the NFTs that account `0x01` owns.
+Execute `Print 0x06 NFTs` by clicking the Execute button in the top right of the editor box.<br/>
+This script returns a list of the NFTs that account `0x06` owns.
 
 </Callout>
 
-Because account `0x01` currently doesn't own any in its collection, it will just print an empty array:
+Because account `0x06` currently doesn't own any in its collection, it will just print an empty array:
 
 ```
 "Account 1 NFTs"
 Result > []
 ```
 
-If the script cannot be executed, it probably means that the NFT collection hasn't been stored correctly in account `0x01`.
-If you run into issues, make sure that you deployed the contract in account `0x01` and that you followed the previous steps correctly.
+If the script cannot be executed, it probably means that the NFT collection hasn't been stored correctly in account `0x06`.
+If you run into issues, make sure that you deployed the contract in account `0x06` and that you followed the previous steps correctly.
 
 ## Using Entitlements
 
@@ -559,13 +559,13 @@ You can see an example of this in the [Marketplace tutorial](./08-marketplace-co
 <Callout type="info">
 
 Open the file named `Mint NFT`.
-Select account `0x01` as the only signer and send the transaction.<br/>
+Select account `0x06` as the only signer and send the transaction.<br/>
 This transaction deposits the minted NFT into the account owner's NFT collection:
 
 </Callout>
 
 ```cadence mint_nft.cdc
-import ExampleNFT from 0x01
+import ExampleNFT from 0x06
 
 // This transaction allows the Minter account to mint an NFT
 // and deposit it into its own collection.
@@ -596,25 +596,25 @@ transaction {
 
 <Callout type="info">
 
-Reopen `Print 0x01 NFTs` and execute the script.
-This prints a list of the NFTs that account `0x01` owns.
+Reopen `Print 0x06 NFTs` and execute the script.
+This prints a list of the NFTs that account `0x06` owns.
 
 </Callout>
 
 ```cadence print_01_nfts.cdc
-import ExampleNFT from 0x01
+import ExampleNFT from 0x06
 
-// Print the NFTs owned by account 0x01.
+// Print the NFTs owned by account 0x06.
 access(all) fun main(): [UInt64] {
-    // Get the public account object for account 0x01
-    let nftOwner = getAccount(0x01)
+    // Get the public account object for account 0x06
+    let nftOwner = getAccount(0x06)
 
     // Find the public Receiver capability for their Collection
     let capability = nftOwner.capabilities.get<&{ExampleNFT.NFTReceiver}>(ExampleNFT.CollectionPublicPath)
 
     // borrow a reference from the capability
     let receiverRef = capability.borrow()
-            ?? panic("Could not borrow receiver reference to 0x01's ExampleNFT.Collection")
+            ?? panic("Could not borrow receiver reference to 0x06's ExampleNFT.Collection")
 
     // Log the NFTs that they own as an array of IDs
     log("Account 1 NFTs")
@@ -622,7 +622,7 @@ access(all) fun main(): [UInt64] {
 }
 ```
 
-You should see that account `0x01` owns the NFT with `id = 1`
+You should see that account `0x06` owns the NFT with `id = 1`
 
 ```
 "Account 1 NFTs"
@@ -636,12 +636,12 @@ with an NFTCollection of their own so they are able to receive NFTs.
 
 <Callout type="info">
 
-Open the file named `Setup Account` and submit the transaction, using account `0x02` as the only signer.
+Open the file named `Setup Account` and submit the transaction, using account `0x07` as the only signer.
 
 </Callout>
 
 ```cadence SetupAccount.cdc
-import ExampleNFT from 0x01
+import ExampleNFT from 0x06
 
 // This transaction configures a user's account
 // to use the NFT contract by creating a new empty collection,
@@ -666,18 +666,18 @@ transaction {
 }
 ```
 
-Account `0x02` should now have an empty `Collection` resource stored in its account storage.
+Account `0x07` should now have an empty `Collection` resource stored in its account storage.
 It has also created and stored a capability to the collection in its `/public/` domain.
 
 <Callout type="info">
 
-Open the file named `Transfer`, select account `0x01` as the only signer, and send the transaction.<br/>
-This transaction transfers a token from account `0x01` to account `0x02`.
+Open the file named `Transfer`, select account `0x06` as the only signer, and send the transaction.<br/>
+This transaction transfers a token from account `0x06` to account `0x07`.
 
 </Callout>
 
 ```cadence transfer_nft.cdc
-import ExampleNFT from 0x01
+import ExampleNFT from 0x06
 
 // This transaction transfers an NFT from one user's collection
 // to another user's collection.
@@ -701,7 +701,7 @@ transaction {
 
     execute {
         // Get the recipient's public account object
-        let recipient = getAccount(0x02)
+        let recipient = getAccount(0x07)
 
         // Get the Collection reference for the receiver
         // getting the public capability and borrowing a reference from it
@@ -719,7 +719,7 @@ transaction {
 See, with the use of Collections and capabilities, now the only account
 that needs to sign a transaction to transfer a token is the one who is sending the token.
 
-Now we can check both accounts' collections to make sure that account `0x02` owns the token and account `0x01` has nothing.
+Now we can check both accounts' collections to make sure that account `0x07` owns the token and account `0x06` has nothing.
 
 <Callout type="info">
 
@@ -728,14 +728,14 @@ Execute the script `Print all NFTs` to see the tokens in each account:
 </Callout>
 
 ```cadence print_all_owned_nfts.cdc
-import ExampleNFT from 0x01
+import ExampleNFT from 0x06
 
-// Print the NFTs owned by accounts 0x01 and 0x02.
+// Print the NFTs owned by accounts 0x06 and 0x07.
 access(all) fun main() {
 
     // Get both public account objects
-    let account1 = getAccount(0x01)
-	let account2 = getAccount(0x02)
+    let account1 = getAccount(0x06)
+	let account2 = getAccount(0x07)
 
     // Find the public Receiver capability for their Collections
     let acct1Capability = account1.capabilities.get(ExampleNFT.CollectionPublicPath)
@@ -765,8 +765,8 @@ You should see something like this in the output:
 [1]
 ```
 
-Account `0x02` has one NFT with ID=1 and account `0x01` has none.
-This shows that the NFT was transferred from account `0x01` to account `0x02`.
+Account `0x07` has one NFT with ID=1 and account `0x06` has none.
+This shows that the NFT was transferred from account `0x06` to account `0x07`.
 
 <img src="https://storage.googleapis.com/flow-resources/documentation-assets/cadence-tuts/accounts-nft-storage.png" />
 

--- a/docs/tutorial/06-fungible-tokens.md
+++ b/docs/tutorial/06-fungible-tokens.md
@@ -101,7 +101,7 @@ but besides that, developers and users are able to treat it and use it just like
 
 We're going to take you through these steps to get comfortable with the fungible token:
 
-1. Deploy the fungible token contract to account `0x01`
+1. Deploy the fungible token contract to account `0x06`
 2. Create a fungible token object and store it in your account storage.
 3. Create a reference to your tokens that others can use to send you tokens.
 4. Set up another account the same way.
@@ -128,7 +128,7 @@ and [Hello, World!](./02-hello-world.md) to learn the basics of the language and
 
 <Callout type="info">
 
-Open the account `0x01` tab to see the file named
+Open the account `0x06` tab to see the file named
 `BasicToken.cdc`. `BasicToken.cdc` should contain the full code for the
 fungible token, which provides the core functionality to store fungible tokens
 in your account and transfer to and accept tokens from other users.
@@ -356,7 +356,7 @@ we can deploy a basic version of it to your account and send some transactions t
 <Callout type="info">
 
 Make sure that you have opened the Fungible Token templates in the playground
-by following the link at the top of this page. You should have Account `0x01`
+by following the link at the top of this page. You should have Account `0x06`
 open and should see the code below.
 
 </Callout>
@@ -459,10 +459,10 @@ Click the `Deploy` button at the top right of the editor to deploy the code.
 
 </Callout>
 
-![Deploy BasicToken on 0x01](./deploy_basic_token.png)
+![Deploy BasicToken on 0x06](./deploy_basic_token.png)
 
 This deployment stores the contract for the basic fungible token
-in the selected account (account `0x01`) so that it can be imported into transactions.
+in the selected account (account `0x06`) so that it can be imported into transactions.
 
 A contract's `init` function runs at contract creation, and never again afterwards.
 In our example, this function stores an instance of the `Vault` object with an initial balance of 30.
@@ -512,7 +512,7 @@ Open the transaction named `Basic Transfer`. <br/>
 ```cadence BasicTransfer.cdc
 // Basic Transfer
 
-import BasicToken from 0x01
+import BasicToken from 0x06
 
 // This transaction is used to withdraw and deposit tokens with a Vault
 
@@ -537,7 +537,7 @@ transaction(amount: UFix64) {
 ```
 
 <Callout type="info">
-  Select account `0x01` as the only signer. <br />
+  Select account `0x06` as the only signer. <br />
   You can enter any number less than 30.0 for the amount of tokens to transfer. <br />
   Click the `Send` button to submit the transaction. <br />
   This transaction withdraws tokens from the main vault and deposits them back
@@ -650,7 +650,7 @@ so that these requirements are enforced by an immutable source of truth that is 
 
 Now, we are going to add these interfaces to our Fungible token along with a minter resource.
 
-Open account `0x02` in the playground. You should see the `ExampleToken` contract.
+Open account `0x07` in the playground. You should see the `ExampleToken` contract.
 In addition to everything that is in the `BasicToken` contract,
 we have also added the `Provider`, `Receiver`, and `Balance` interfaces described above.
 
@@ -732,14 +732,14 @@ Let's create capabilities to your `Vault` so that a separate account can send to
 
 <Callout type="info">
 
-Before we submit a transaction interacting with ExampleToken resources, we'll need to deploy the contract to account `0x02`:<br/>
+Before we submit a transaction interacting with ExampleToken resources, we'll need to deploy the contract to account `0x07`:<br/>
 1. Select Contract 2 in the playground sidebar (the ExampleToken contract)<br/>
-2. Make sure that signer `0x02` is selected as the deploying address<br/>
+2. Make sure that signer `0x07` is selected as the deploying address<br/>
 3. Click "Deploy"
 
 </Callout>
 
-![Deploy ExampleToken to 0x02](./deploy_example_token.png)
+![Deploy ExampleToken to 0x07](./deploy_example_token.png)
 
 Now we can continue on to configure Capabilities on the ExampleToken Vault.
 
@@ -752,7 +752,7 @@ Open the transaction named `Create Link`. <br/>
 
 ```cadence issue_capability.cdc
 
-import ExampleToken from 0x02
+import ExampleToken from 0x07
 
 // This transaction creates a capability
 // that is linked to the account's token vault.
@@ -778,7 +778,7 @@ transaction {
     // by getting the public capability and checking
     // that it points to a valid `Vault` object
     // that implements the `Receiver` interface
-    getAccount(0x02).capabilities.get<&{ExampleToken.Receiver}>(/public/CadenceFungibleTokenTutorialReceiver)
+    getAccount(0x07).capabilities.get<&{ExampleToken.Receiver}>(/public/CadenceFungibleTokenTutorialReceiver)
                     .check():
                     "Vault Receiver Reference was not created correctly"
     }
@@ -822,7 +822,7 @@ post {
 // by getting the public capability and checking
 // that it points to a valid `Vault` object
 // that implements the `Receiver` interface
-getAccount(0x02).capabilities.get<&{ExampleToken.Receiver}>(/public/CadenceFungibleTokenTutorialReceiver)
+getAccount(0x07).capabilities.get<&{ExampleToken.Receiver}>(/public/CadenceFungibleTokenTutorialReceiver)
                     .check():
                     "Vault Receiver Reference was not created correctly"
 }
@@ -836,7 +836,7 @@ that the capability contains a valid link to a valid object in storage that is t
 
 Now that we understand the transaction, time to submit it:<br/>
 
-1. Select account `0x02` as the only signer.<br/>
+1. Select account `0x07` as the only signer.<br/>
 2. Click the `Send` button to submit the transaction.<br/>
 3. This transaction creates a new public capability to your `Vault`
    and checks that it was created correctly.
@@ -847,25 +847,25 @@ Now that we understand the transaction, time to submit it:<br/>
 
 ---
 
-Now, we are going to run a transaction that sends 10 tokens to account `0x03`.
-We will do this by calling the `withdraw` function on account `0x02`'s Vault,
+Now, we are going to run a transaction that sends 10 tokens to account `0x08`.
+We will do this by calling the `withdraw` function on account `0x07`'s Vault,
 which creates a temporary Vault object for moving the tokens,
-then deposits those tokens into account `0x03`'s vault by calling the `deposit` function on their vault.
+then deposits those tokens into account `0x08`'s vault by calling the `deposit` function on their vault.
 
 <Callout type="info">
 
-Account `0x03` has not been set up to receive tokens, so we will do that now:
+Account `0x08` has not been set up to receive tokens, so we will do that now:
 
 1. Open the transaction `Setup Account`.<br/>
-2. Select account `0x03` as the only signer.<br/>
-3. Click the `Send` button to set up account `0x03` so that it can receive tokens.
+2. Select account `0x08` as the only signer.<br/>
+3. Click the `Send` button to set up account `0x08` so that it can receive tokens.
 
 </Callout>
 
 ```cadence SetupAccount.cdc
 // Setup Account
 
-import ExampleToken from 0x02
+import ExampleToken from 0x07
 
 // This transaction configures an account to store and receive tokens defined by
 // the ExampleToken contract.
@@ -889,7 +889,7 @@ transaction {
     }
 
     post {
-        getAccount(0x03).capabilities.get<&{ExampleToken.Receiver}>(/public/CadenceFungibleTokenTutorialReceiver)
+        getAccount(0x08).capabilities.get<&{ExampleToken.Receiver}>(/public/CadenceFungibleTokenTutorialReceiver)
                             .check():
                             "Vault Receiver Reference was not created correctly"
     }
@@ -897,15 +897,15 @@ transaction {
 }
 ```
 
-Here we perform the same actions that account `0x02` did to set up its `Vault`, but all in one transaction.
-Account `0x03` is ready to start building its fortune! As you can see, when we created the Vault for account `0x03`,
+Here we perform the same actions that account `0x07` did to set up its `Vault`, but all in one transaction.
+Account `0x08` is ready to start building its fortune! As you can see, when we created the Vault for account `0x08`,
 we had to create one with a balance of zero by calling the `createEmptyVault()` function.
 Resource creation is restricted to the contract where it is defined, so in this way, the Fungible Token smart contract can ensure that
 nobody is able to create new tokens out of thin air.
 
-As part of the initial deployment process for the ExampleToken contract, account `0x02` created a `VaultMinter` object.
+As part of the initial deployment process for the ExampleToken contract, account `0x07` created a `VaultMinter` object.
 By using this object, the account that owns it can mint new tokens.
-Right now, account `0x02` owns it, so it has sole power to mint new tokens.
+Right now, account `0x07` owns it, so it has sole power to mint new tokens.
 We could have had a `mintTokens` function defined in the contract,
 but then we would have to check the sender of the function call to make sure that they are authorized,
 which is not the recommended way to perform access control.
@@ -913,19 +913,19 @@ which is not the recommended way to perform access control.
 As we explained before, the resource model plus capability security
 handles this access control for us as a built in language construct
 instead of having to be defined in the code.
-If account `0x02` wanted to authorize another account to mint tokens,
+If account `0x07` wanted to authorize another account to mint tokens,
 they could either move the `VaultMinter` object to the other account,
 or give the other account a private capability to the single `VaultMinter`.
 Or, if they didn't want minting to be possible after deployment,
 they would simply mint all the tokens at contract initialization
 and not even include the `VaultMinter` in the contract.
 
-In the next transaction, account `0x02` will mint 30 new tokens and deposit them into account `0x03`'s newly created Vault.
+In the next transaction, account `0x07` will mint 30 new tokens and deposit them into account `0x08`'s newly created Vault.
 
 <Callout type="info">
 
 1. Open the `Mint Tokens` transaction.<br/>
-2. Select only account `0x02` as a signer and send `Mint Tokens` to mint 30 tokens for account `0x03`.
+2. Select only account `0x07` as a signer and send `Mint Tokens` to mint 30 tokens for account `0x08`.
 
 </Callout>
 
@@ -934,7 +934,7 @@ In the next transaction, account `0x02` will mint 30 new tokens and deposit them
 ```cadence mint_tokens.cdc
 // Mint Tokens
 
-import ExampleToken from 0x02
+import ExampleToken from 0x07
 
 // This transaction mints tokens and deposits them into account 3's vault
 transaction {
@@ -951,8 +951,8 @@ transaction {
         self.mintingRef = acct.storage.borrow<&ExampleToken.VaultMinter>(from: /storage/CadenceFungibleTokenTutorialMinter)
             ?? panic("Could not borrow a reference to the minter")
 
-        // Get the public account object for account 0x03
-        let recipient = getAccount(0x03)
+        // Get the public account object for account 0x08
+        let recipient = getAccount(0x08)
 
         // Get their public receiver capability
         self.receiver = recipient.capabilities.get<&ExampleToken.Vault{ExampleToken.Receiver}>
@@ -964,7 +964,7 @@ transaction {
         // Mint 30 tokens and deposit them into the recipient's Vault
         self.mintingRef.mintTokens(amount: 30.0, recipient: self.receiver)
 
-        log("30 tokens minted and deposited to account 0x03")
+        log("30 tokens minted and deposited to account 0x08")
     }
 }
 ```
@@ -997,11 +997,11 @@ self.receiverRef = cap.borrow<&{ExampleToken.Receiver}>()
         ?? panic("Could not borrow a reference to the receiver")
 ```
 
-In the execute phase, we simply use the reference to mint 30 tokens and deposit them into the `Vault` of account `0x03`.
+In the execute phase, we simply use the reference to mint 30 tokens and deposit them into the `Vault` of account `0x08`.
 
 ## Check Account Balances
 
-Now, both account `0x02` and account `0x03` should have a `Vault` object in their storage that has a balance of 30 tokens.
+Now, both account `0x07` and account `0x08` should have a `Vault` object in their storage that has a balance of 30 tokens.
 They both should also have a `Receiver` capability stored in their `/public/` domains that links to their stored `Vault`.
 
 <img src="https://storage.googleapis.com/flow-resources/documentation-assets/cadence-tuts/account-balances.png" />
@@ -1027,14 +1027,14 @@ Open the script named `Get Balances` in the scripts pane.
 ```cadence get_balances.cdc
 // Get Balances
 
-import FungibleToken from 0x02
+import FungibleToken from 0x07
 
 // This script reads the Vault balances of two accounts.
 access(all)
 fun main() {
     // Get the accounts' public account objects
-    let acct2 = getAccount(0x02)
-    let acct3 = getAccount(0x03)
+    let acct2 = getAccount(0x07)
+    let acct3 = getAccount(0x08)
 
     // Get references to the account's receivers
     // by getting their public capability
@@ -1063,8 +1063,8 @@ Execute `Get Balances` by clicking the Execute button.
 
 This should ensure the following:
 
-- Account `0x02`'s balance is 30
-- Account `0x03`'s balance is 30
+- Account `0x07`'s balance is 30
+- Account `0x08`'s balance is 30
 
 If correct, you should see the following lines:
 
@@ -1086,7 +1086,7 @@ Now that we have two accounts, each with a `Vault`, we can see how they transfer
 <Callout type="info">
 
 1. Open the transaction named `Transfer Tokens`. <br/>
-2. Select account `0x03` as a signer and send the transaction. <br/>
+2. Select account `0x08` as a signer and send the transaction. <br/>
 3. `Transfer Tokens` should contain the following code for sending tokens to another user:
 
 </Callout>
@@ -1094,7 +1094,7 @@ Now that we have two accounts, each with a `Vault`, we can see how they transfer
 ```cadence transfer_tokens.cdc
 // Transfer Tokens
 
-import ExampleToken from 0x02
+import ExampleToken from 0x07
 
 // This transaction is a template for a transaction that
 // could be used by anyone to send tokens to another account
@@ -1115,7 +1115,7 @@ transaction {
 
   execute {
     // get the recipient's public account object
-    let recipient = getAccount(0x02)
+    let recipient = getAccount(0x07)
 
     // get the recipient's Receiver reference to their Vault
     // by borrowing the reference from the public capability
@@ -1158,7 +1158,7 @@ Execute `Get Balances` again.
 
 </Callout>
 
-If correct, you should see the following lines indicating that account `0x02`'s balance is 40 and account `0x03`'s balance is 20:
+If correct, you should see the following lines indicating that account `0x07`'s balance is 40 and account `0x08`'s balance is 20:
 
 ```
 "Account 2 Balance"

--- a/docs/tutorial/07-marketplace-setup.md
+++ b/docs/tutorial/07-marketplace-setup.md
@@ -44,21 +44,21 @@ Having your playground in this state is necessary to follow the [Composable Smar
 
 ---
 
-1. Open account `0x01`. Make sure the Fungible Token definitions in `ExampleToken.cdc` from the fungible token tutorial are in this account.
-2. Deploy the `ExampleToken` code to account `0x01`.
+1. Open account `0x06`. Make sure the Fungible Token definitions in `ExampleToken.cdc` from the fungible token tutorial are in this account.
+2. Deploy the `ExampleToken` code to account `0x06`.
 3. Switch to the `ExampleNFT` contract (Contract 2)
-4. Make sure you have the NFT definitions in `ExampleNFT.cdc` from the Non-fungible token tutorial in account `0x02`.
-5. Deploy the NFT code to account `0x02` by selecting it as the deploying signer.
+4. Make sure you have the NFT definitions in `ExampleNFT.cdc` from the Non-fungible token tutorial in account `0x07`.
+5. Deploy the NFT code to account `0x07` by selecting it as the deploying signer.
 6. Run the transaction in Transaction 1. This is the `SetupAccount1Transaction.cdc` file.
-   Use account `0x01` as the only signer to set up account `0x01`'s storage.
+   Use account `0x06` as the only signer to set up account `0x06`'s storage.
 
 ```cadence SetupAccount1Transaction.cdc
 // SetupAccount1Transaction.cdc
 
-import ExampleToken from 0x01
-import ExampleNFT from 0x02
+import ExampleToken from 0x06
+import ExampleNFT from 0x07
 
-// This transaction sets up account 0x01 for the marketplace tutorial
+// This transaction sets up account 0x06 for the marketplace tutorial
 // by publishing a Vault reference and creating an empty NFT Collection.
 transaction {
   prepare(acct: auth(SaveValue, StorageCapabilities) &Account) {
@@ -81,17 +81,17 @@ transaction {
 ```
 
 7. Run the transaction in Transaction 2. This is the `SetupAccount2Transaction.cdc` file.
-Use account `0x02` as the only signer to set up account `0x02`'s storage.
+Use account `0x07` as the only signer to set up account `0x07`'s storage.
 
 ```cadence SetupAccount2Transaction.cdc
 // SetupAccount2Transaction.cdc
 
-import ExampleToken from 0x01
-import ExampleNFT from 0x02
+import ExampleToken from 0x06
+import ExampleNFT from 0x07
 
-// This transaction adds an empty Vault to account 0x02
+// This transaction adds an empty Vault to account 0x07
 // and mints an NFT with id=1 that is deposited into
-// the NFT collection on account 0x01.
+// the NFT collection on account 0x06.
 transaction {
 
   // Private reference to this account's minter resource
@@ -116,7 +116,7 @@ transaction {
   }
   execute {
     // Get the recipient's public account object
-    let recipient = getAccount(0x01)
+    let recipient = getAccount(0x06)
 
     // Get the Collection reference for the receiver
     // getting the public capability and borrowing a reference from it
@@ -124,23 +124,23 @@ transaction {
         .borrow<&{ExampleNFT.NFTReceiver}>(ExampleNFT.CollectionPublicPath)
         ?? panic("Could not borrow receiver reference")
 
-    // Mint an NFT and deposit it into account 0x01's collection
+    // Mint an NFT and deposit it into account 0x06's collection
     receiverRef.deposit(token: <-self.minterRef.mintNFT())
   }
 }
 ```
 
 8. Run the transaction in Transaction 3. This is the `SetupAccount1TransactionMinting.cdc` file.
-   Use account `0x01` as the only signer to mint fungible tokens for account 1 and 2.
+   Use account `0x06` as the only signer to mint fungible tokens for account 1 and 2.
 
 ```cadence SetupAccount1TransactionMinting.cdc
 // SetupAccount1TransactionMinting.cdc
 
-import ExampleToken from 0x01
-import ExampleNFT from 0x02
+import ExampleToken from 0x06
+import ExampleNFT from 0x07
 
 // This transaction mints tokens for both accounts using
-// the minter stored on account 0x01.
+// the minter stored on account 0x06.
 transaction {
 
   // Public Vault Receiver References for both accounts
@@ -151,14 +151,14 @@ transaction {
   let minterRef: &ExampleToken.VaultMinter
 
   prepare(acct: auth(SaveValue, StorageCapabilities, BorrowValue) &Account) {
-    // Get the public object for account 0x02
-    let account2 = getAccount(0x02)
+    // Get the public object for account 0x07
+    let account2 = getAccount(0x07)
 
     // Retrieve public Vault Receiver references for both accounts
     self.acct1Capability = acct.capabilities.get<&{ExampleToken.Receiver}>(/public/CadenceFungibleTokenTutorialReceiver)
     self.acct2Capability = account2.capabilities.get<&{ExampleToken.Receiver}>(/public/CadenceFungibleTokenTutorialReceiver)
 
-    // Get the stored Minter reference for account 0x01
+    // Get the stored Minter reference for account 0x06
     self.minterRef = acct.storage.borrow<&ExampleToken.VaultMinter>(from: /storage/CadenceFungibleTokenTutorialMinter)
         ?? panic("Could not borrow owner's vault minter reference")
   }
@@ -176,8 +176,8 @@ transaction {
 ```cadence CheckSetupScript.cdc
 // CheckSetupScript.cdc
 
-import ExampleToken from 0x01
-import ExampleNFT from 0x02
+import ExampleToken from 0x06
+import ExampleNFT from 0x07
 
 /// Allows the script to return the ownership info
 /// of all the accounts
@@ -198,12 +198,12 @@ access(all) struct OwnerInfo {
 
 // This script checks that the accounts are set up correctly for the marketplace tutorial.
 //
-// Account 0x01: Vault Balance = 40, NFT.id = 1
-// Account 0x02: Vault Balance = 20, No NFTs
+// Account 0x06: Vault Balance = 40, NFT.id = 1
+// Account 0x07: Vault Balance = 20, No NFTs
 access(all) fun main(): OwnerInfo {
     // Get the accounts' public account objects
-    let acct1 = getAccount(0x01)
-    let acct2 = getAccount(0x02)
+    let acct1 = getAccount(0x06)
+    let acct2 = getAccount(0x07)
 
     // Get references to the account's receivers
     // by getting their public capability

--- a/docs/tutorial/08-marketplace-compose.md
+++ b/docs/tutorial/08-marketplace-compose.md
@@ -67,7 +67,7 @@ and non-fungible tokens into a single contract that gives users control over the
 To accomplish this, we're going to take you through these steps to create a composable smart contract and get comfortable with the marketplace:
 
 1. Ensure that your fungible token and non-fungible token contracts are deployed and set up correctly.
-2. Deploy the marketplace type declarations to account `0x03`.
+2. Deploy the marketplace type declarations to account `0x08`.
 3. Create a marketplace object and store it in your account storage, putting an NFT up for sale and publishing a public capability for your sale.
 4. Use a different account to purchase the NFT from the sale.
 5. Run a script to verify that the NFT was purchased.
@@ -110,8 +110,8 @@ You can run the `1. CheckSetupScript.cdc` script to ensure that your accounts ar
 
 ```cadence CheckSetupScript.cdc
 
-import ExampleToken from 0x01
-import ExampleNFT from 0x02
+import ExampleToken from 0x06
+import ExampleNFT from 0x07
 
 /// Allows the script to return the ownership info
 /// of all the accounts
@@ -132,12 +132,12 @@ access(all) struct OwnerInfo {
 
 // This script checks that the accounts are set up correctly for the marketplace tutorial.
 //
-// Account 0x01: Vault Balance = 40, NFT.id = 1
-// Account 0x02: Vault Balance = 20, No NFTs
+// Account 0x06: Vault Balance = 40, NFT.id = 1
+// Account 0x07: Vault Balance = 20, No NFTs
 access(all) fun main(): OwnerInfo {
     // Get the accounts' public account objects
-    let acct1 = getAccount(0x01)
-    let acct2 = getAccount(0x02)
+    let acct1 = getAccount(0x06)
+    let acct2 = getAccount(0x07)
 
     // Get references to the account's receivers
     // by getting their public capability
@@ -212,15 +212,15 @@ Time to deploy the marketplace contract:
 <Callout type="info">
 
 1. Switch to the ExampleMarketplace contract (Contract 3).<br/>
-2. With `ExampleMarketplace.cdc` open, select account `0x03` from the deployment modal in the bottom right and deploy.
+2. With `ExampleMarketplace.cdc` open, select account `0x08` from the deployment modal in the bottom right and deploy.
 
 </Callout>
 
 `ExampleMarketplace.cdc` should contain the following contract definition:
 
 ```cadence ExampleMarketplace.cdc
-import ExampleToken from 0x01
-import ExampleNFT from 0x02
+import ExampleToken from 0x06
+import ExampleNFT from 0x07
 
 // ExampleMarketplace.cdc
 //
@@ -464,8 +464,8 @@ Then, users can get that capability from [the public path](../language/accounts/
 borrow it, and access the functionality that the owner specified.
 
 ```cadence
-// Get account 0x01's PublicAccount object
-let publicAccount = getAccount(0x01)
+// Get account 0x06's PublicAccount object
+let publicAccount = getAccount(0x06)
 
 // Retrieve a Vault Receiver Capability from the account's public storage
 let acct1Capability = acct.capabilities.get<&{ExampleToken.Receiver}>(
@@ -553,23 +553,23 @@ Enough explaining! Lets execute some code!
 ## Using the Marketplace
 
 At this point, we should have an `ExampleToken.Vault` and an `Example.NFT.Collection` in both accounts' storage.
-Account `0x01` should have an NFT in their collection and the `ExampleMarketplace` contract should be deployed to `0x03`.
+Account `0x06` should have an NFT in their collection and the `ExampleMarketplace` contract should be deployed to `0x08`.
 
-You can create a `SaleCollection` and list account `0x01`'s token for sale by following these steps:
+You can create a `SaleCollection` and list account `0x06`'s token for sale by following these steps:
 
 <Callout type="info">
 
 1. Open Transaction 4, `CreateSale.cdc` <br/>
-2. Select account `0x01` as the only signer and click the `Send` button to submit the transaction.
+2. Select account `0x06` as the only signer and click the `Send` button to submit the transaction.
 
 </Callout>
 
 ```cadence Transaction4.cdc
 // CreateSale.cdc
 
-import ExampleToken from 0x01
-import ExampleNFT from 0x02
-import ExampleMarketplace from 0x03
+import ExampleToken from 0x06
+import ExampleNFT from 0x07
+import ExampleMarketplace from 0x08
 
 // This transaction creates a new Sale Collection object,
 // lists an NFT for sale, puts it in account storage,
@@ -615,20 +615,20 @@ This transaction:
 Let's run a script to ensure that the sale was created correctly.
 
 1. Open Script 2: `GetSaleIDs.cdc`
-1. Click the `Execute` button to print the ID and price of the NFT that account `0x01` has for sale.
+1. Click the `Execute` button to print the ID and price of the NFT that account `0x06` has for sale.
 
 ```cadence GetSaleIDs.cdc
 // GetSaleIDs.cdc
 
-import ExampleToken from 0x01
-import ExampleNFT from 0x02
-import ExampleMarketplace from 0x03
+import ExampleToken from 0x06
+import ExampleNFT from 0x07
+import ExampleMarketplace from 0x08
 
-// This script returns the NFTs that account 0x01 has for sale.
+// This script returns the NFTs that account 0x06 has for sale.
 access(all)
 fun main(): [UInt64] {
-    // Get the public account object for account 0x01
-    let account1 = getAccount(0x01)
+    // Get the public account object for account 0x06
+    let account1 = getAccount(0x06)
 
     // Find the public Sale reference to their Collection
     let acct1saleRef = account1.capabilities.get<&{ExampleMarketplace.SalePublic}(/public/NFTSale)>
@@ -655,19 +655,19 @@ The buyer can now purchase the seller's NFT by using the transaction in `Transac
 <Callout type="info">
 
 1. Open Transaction 5: `PurchaseSale.cdc` file<br/>
-2. Select account `0x02` as the only signer and click the `Send` button
+2. Select account `0x07` as the only signer and click the `Send` button
 
 </Callout>
 
 ```cadence PurchaseSale.cdc
 // PurchaseSale.cdc
 
-import ExampleToken from 0x01
-import ExampleNFT from 0x02
-import ExampleMarketplace from 0x03
+import ExampleToken from 0x06
+import ExampleNFT from 0x07
+import ExampleMarketplace from 0x08
 
 // This transaction uses the signers Vault tokens to purchase an NFT
-// from the Sale collection of account 0x01.
+// from the Sale collection of account 0x06.
 transaction {
 
     // Capability to the buyer's NFT collection where they
@@ -692,7 +692,7 @@ transaction {
 
     execute {
         // get the read-only account storage of the seller
-        let seller = getAccount(0x01)
+        let seller = getAccount(0x06)
 
         // get the reference to the seller's sale
         let saleRef = seller.capabilities.get<&{ExampleMarketplace.SalePublic}>(/public/NFTSale)
@@ -710,7 +710,7 @@ This transaction:
 
 1. Gets the capability to the buyer's NFT receiver
 1. Get a reference to their token vault and withdraws the sale purchase amount
-1. Gets the public account object for account `0x01`
+1. Gets the public account object for account `0x06`
 1. Gets the reference to the seller's public sale
 1. Calls the `purchase` function, passing in the tokens and the `Collection` reference. Then `purchase` deposits the bought NFT directly into the buyer's collection.
 
@@ -720,8 +720,8 @@ This transaction:
 
 You can run now run a script to verify that the NFT was purchased correctly because:
 
-- account `0x01` has 50 tokens and does not have any NFTs for sale or in their collection and account
-- account `0x02` has 10 tokens and an NFT with id=1
+- account `0x06` has 50 tokens and does not have any NFTs for sale or in their collection and account
+- account `0x07` has 10 tokens and an NFT with id=1
 
 To run a script that verifies the NFT was purchased correctly, follow these steps:
 
@@ -736,8 +736,8 @@ To run a script that verifies the NFT was purchased correctly, follow these step
 
 ```cadence Script3.cdc
 // VerifyAfterPurchase
-import ExampleToken from 0x01
-import ExampleNFT from 0x02
+import ExampleToken from 0x06
+import ExampleNFT from 0x07
 
 /// Allows the script to return the ownership info
 /// of all the accounts
@@ -758,12 +758,12 @@ access(all) struct OwnerInfo {
 
 // This script checks that the accounts are in the correct state after purchasing a listing.
 //
-// Account 0x01: Vault Balance = 50, No NFTs
-// Account 0x02: Vault Balance = 10, NFT.id = 1
+// Account 0x06: Vault Balance = 50, No NFTs
+// Account 0x07: Vault Balance = 10, NFT.id = 1
 access(all) fun main(): OwnerInfo {
     // Get the accounts' public account objects
-    let acct1 = getAccount(0x01)
-    let acct2 = getAccount(0x02)
+    let acct1 = getAccount(0x06)
+    let acct2 = getAccount(0x07)
 
     // Get references to the account's receivers
     // by getting their public capability

--- a/docs/tutorial/09-voting.md
+++ b/docs/tutorial/09-voting.md
@@ -34,7 +34,7 @@ This tutorial will provide a trivial example for how this might be achieved by u
 
 We'll take you through these steps to get comfortable with the Voting contract.
 
-1. Deploy the contract to account `0x01`
+1. Deploy the contract to account `0x06`
 2. Create proposals for users to vote on
 3. Use a transaction with multiple signers to directly transfer the `Ballot` resource to another account.
 4. Record and cast your vote in the central Voting contract
@@ -61,12 +61,12 @@ Time to deploy the contract we'll be working with:
 <Callout type="info">
 
 1. Open Contract 1 - the `ApprovalVoting` contract.<br/>
-2. In the bottom right deployment modal, press the arrow to expand and make sure account `0x01` is selected as the signer.<br/>
-3. Click the Deploy button to deploy it to account `0x01`
+2. In the bottom right deployment modal, press the arrow to expand and make sure account `0x06` is selected as the signer.<br/>
+3. Click the Deploy button to deploy it to account `0x06`
 
 </Callout>
 
-![Deploy ApprovalVoting to account 0x01](deploy_approval_voting.png)
+![Deploy ApprovalVoting to account 0x06](deploy_approval_voting.png)
 
 The deployed contract should have the following contents:
 
@@ -265,17 +265,17 @@ Performing the common actions in this voting contract only takes three types of 
 2. Send `Ballot` to a voter
 3. Cast Vote
 
-We have a transaction for each step that we provide for you. With the `ApprovalVoting` contract to account `0x01`:
+We have a transaction for each step that we provide for you. With the `ApprovalVoting` contract to account `0x06`:
 
 <Callout type="info">
 
 1. Open Transaction 1 which should have `Transaction1.cdc`<br/>
-2. Submit the transaction with account `0x01` selected as the only signer.
+2. Submit the transaction with account `0x06` selected as the only signer.
 
 </Callout>
 
 ```cadence Transaction1.cdc
-import ApprovalVoting from 0x01
+import ApprovalVoting from 0x06
 
 // This transaction allows the administrator of the Voting contract
 // to create new proposals for voting and save them to the smart contract
@@ -324,14 +324,14 @@ The playground will give you an error if the number of selected signers is diffe
 <Callout type="info">
 
 1. Open Transaction 2 which should have `Transaction2.cdc`.<br/>
-2. Select account `0x01` as a signer first, then also select account `0x02`.<br/>
+2. Select account `0x06` as a signer first, then also select account `0x07`.<br/>
 3. Submit the transaction by clicking the `Send` button
 
 </Callout>
 
 ```cadence Transaction2.cdc
 
-import ApprovalVoting from 0x01
+import ApprovalVoting from 0x06
 
 // This transaction allows the administrator of the Voting contract
 // to create a new ballot and store it in a voter's account
@@ -361,22 +361,22 @@ This transaction has two signers as `prepare` parameters, so it is able to acces
 
 Because of this, we can perform a direct transfer of the `Ballot` by creating it with the admin's `issueBallot` function and then directly store it in the voter's storage by using the `save` function.
 
-Account `0x02` should now have a `Ballot` resource object in its account storage. You can confirm this by selecting `0x02` from the lower-left sidebar and seeing `Ballot` resource listed under the `Storage` field.
+Account `0x07` should now have a `Ballot` resource object in its account storage. You can confirm this by selecting `0x07` from the lower-left sidebar and seeing `Ballot` resource listed under the `Storage` field.
 
 ## Casting a Vote
 
-Now that account `0x02` has a `Ballot` in their storage, they can cast their vote. To do this, they will call the `vote` method on their stored resource, then cast that `Ballot` by passing it to the `cast` function in the main smart contract.
+Now that account `0x07` has a `Ballot` in their storage, they can cast their vote. To do this, they will call the `vote` method on their stored resource, then cast that `Ballot` by passing it to the `cast` function in the main smart contract.
 
 <Callout type="info">
 
 1. Open Transaction 3 which should contain `Transaction3.cdc`.<br/>
-2. Select account `0x02` as the only transaction signer.<br/>
+2. Select account `0x07` as the only transaction signer.<br/>
 3. Click the `send` button to submit the transaction.
 
 </Callout>
 
 ```cadence Transaction3.cdc
-import ApprovalVoting from 0x01
+import ApprovalVoting from 0x06
 
 // This transaction allows a voter to select the votes they would like to make
 // and cast that vote by using the castVote function
@@ -413,7 +413,7 @@ At any time, anyone could read the current tally of votes by directly reading th
 </Callout>
 
 ```cadence Script1.cdc
-import ApprovalVoting from 0x01
+import ApprovalVoting from 0x06
 
 // This script allows anyone to read the tallied votes for each proposal
 //

--- a/docs/tutorial/10-resources-compose.md
+++ b/docs/tutorial/10-resources-compose.md
@@ -31,7 +31,7 @@ but reading the rest is necessary to understand the language's design.
 Resources owning other resources is a powerful feature in the world of blockchain and smart contracts.
 To showcase how this feature works on Flow, this tutorial will take you through these steps with a composable NFT:
 
-1. Deploy the `Kitty` and `KittyHat` definitions to account `0x01`
+1. Deploy the `Kitty` and `KittyHat` definitions to account `0x06`
 2. Create a `Kitty` and two `KittyHat`s and store them in your account
 3. Move the Kitties and Hats around to see how composable NFTs function on Flow
 
@@ -72,12 +72,12 @@ Here is a basic example of how we can replicate this feature in Cadence:
 <Callout type="info">
 
 1. Open Contract 1, the `KittyVerse.cdc` contract<br/>
-2. In the bottom right deployment modal, press the arrow to expand and make sure account `0x01` is selected as the signer.<br/>
-3. Click the Deploy button to deploy the contract to account `0x01`
+2. In the bottom right deployment modal, press the arrow to expand and make sure account `0x06` is selected as the signer.<br/>
+3. Click the Deploy button to deploy the contract to account `0x06`
 
 </Callout>
 
-![Deploy KittyVerse to account 0x01](deploy_kittyverse.png)
+![Deploy KittyVerse to account 0x06](deploy_kittyverse.png)
 
 The deployed contract should have the following contents:
 
@@ -193,13 +193,13 @@ A Kitty owner can take the hats off the Kitty and transfer them individually. Or
 Here is a transaction to create a `Kitty` and a `KittyHat`, store the hat in the Kitty, then store it in your account storage.
 
 1. Open `Transaction1.cdc`.
-1. Select account `0x01` as the only signer.
+1. Select account `0x06` as the only signer.
 1. Send the transaction by clicking the Send button.
 
 The transaction you sent just executed the following code:
 
 ```cadence Transaction1.cdc
-import KittyVerse from 0x01
+import KittyVerse from 0x06
 
 // This transaction creates a new kitty, creates two new hats and
 // puts the hats on the cat. Then it stores the kitty in account storage.
@@ -243,7 +243,7 @@ Now we can run a transaction to move the Kitty along with its hat, remove the co
 <Callout type="info">
 
 1. Open `Transaction2.cdc`.<br/>
-2. Select account `0x01` as the only signer.<br/>
+2. Select account `0x06` as the only signer.<br/>
 3. Send the transaction.
 
 </Callout>
@@ -251,7 +251,7 @@ Now we can run a transaction to move the Kitty along with its hat, remove the co
 In this transaction, we executed the following code:
 
 ```cadence Transaction2.cdc
-import KittyVerse from 0x01
+import KittyVerse from 0x06
 
 // This transaction moves a kitty out of storage, takes the cowboy hat off of the kitty,
 // calls its tip hat function, and then moves it back into storage.


### PR DESCRIPTION
All the tutorial links are broken right now, so I've updated the first four tutorials and fixed the import addresses for the rest of them to at least have something that is somewhat working on the docs site right now.

I'd like to merge this ASAP if possible

I'll be going through and updating the rest in the next few days.