### PR TITLE
Remove Callout and Admonition mapping

### DIFF
--- a/src/theme/MDXComponents.js
+++ b/src/theme/MDXComponents.js
@@ -1,12 +1,7 @@
 // Import the original mapper
 import MDXComponents from '@theme-original/MDXComponents';
-import Admonition from '@theme/Admonition';
 
 export default {
   // Re-use the default mapping
-  ...MDXComponents,
-  // Map the "<Highlight>" tag to our Highlight component
-  // `Highlight` will receive all props that were passed to `<Highlight>` in MDX
-  Callout: Admonition,
-  Admonition,
+  ...MDXComponents
 };


### PR DESCRIPTION
With #164 merged, `Callout` or `Admonition` components should not be used directly anymore, so remove the mapping for them.