### PR TITLE
Edit first three lang ref articles

### DIFF
--- a/docs/language/constants-and-variables.md
+++ b/docs/language/constants-and-variables.md
@@ -3,21 +3,11 @@ title: Constants and Variable Declarations
 sidebar_position: 2
 ---
 
-Constants and variables are declarations that bind
-a value and [type](./type-safety.md) to an identifier.
-Constants are initialized with a value and cannot be reassigned afterwards.
-Variables are initialized with a value and can be reassigned later.
-Declarations can be created in any scope, including the global scope.
+Constants and variables are declarations that bind a value and [type] to an identifier. Constants are initialized with a value and cannot be reassigned afterwards. Variables are initialized with a value and can be reassigned later. Declarations can be created in any scope, including the global scope.
 
-Constant means that the *identifier's* association is constant,
-not the *value* itself –
-the value may still be changed if it is mutable.
+Constant means that the _identifier's_ association is constant, not the _value_ itself — the value may still be changed if it is mutable.
 
-Constants are declared using the `let` keyword. Variables are declared
-using the `var` keyword.
-The keywords are followed by the identifier,
-an optional [type annotation](./type-annotations.md), an equals sign `=`,
-and the initial value.
+Constants are declared using the `let` keyword. Variables are declared using the `var` keyword. The keywords are followed by the identifier, an optional [type annotation], an equals sign `=`, and the initial value:
 
 ```cadence
 // Declare a constant named `a`.
@@ -37,7 +27,7 @@ var b = 3
 b = 4
 ```
 
-Variables and constants **must** be initialized.
+Variables and constants **must** be initialized:
 
 ```cadence
 // Invalid: the constant has no initial value.
@@ -45,10 +35,7 @@ Variables and constants **must** be initialized.
 let a
 ```
 
-The names of the variable or constant
-declarations in each scope must be unique.
-Declaring another variable or constant with a name that is already
-declared in the current scope is invalid, regardless of kind or type.
+The names of the variable or constant declarations in each scope must be unique. Declaring another variable or constant with a name that is already declared in the current scope is invalid, regardless of kind or type:
 
 ```cadence
 // Declare a constant named `a`.
@@ -76,7 +63,7 @@ var b = 4
 var a = 5
 ```
 
-However, variables can be redeclared in sub-scopes.
+However, variables can be redeclared in sub-scopes:
 
 ```cadence
 // Declare a constant named `a`.
@@ -94,9 +81,14 @@ if true {
 // `a` is `1`
 ```
 
-A variable cannot be used as its own initial value.
+A variable cannot be used as its own initial value:
 
 ```cadence
 // Invalid: Use of variable in its own initial value.
 let a = a
 ```
+
+<!-- Relative links. Will not render on the page -->
+
+[type]: ./type-safety.md
+[type annotation]: ./type-annotations.md

--- a/docs/language/constants-and-variables.md
+++ b/docs/language/constants-and-variables.md
@@ -5,7 +5,7 @@ sidebar_position: 2
 
 Constants and variables are declarations that bind a value and [type] to an identifier. Constants are initialized with a value and cannot be reassigned afterwards. Variables are initialized with a value and can be reassigned later. Declarations can be created in any scope, including the global scope.
 
-Constant means that the _identifier's_ association is constant, not the _value_ itself — the value may still be changed if it is mutable.
+Constant means that the _identifier's_ association is constant, not the _value_ itself — the value may still be changed if it is mutable.  For example, you can change the values inside of a constant array, but you cannot replace the array assignment with a new array.
 
 Constants are declared using the `let` keyword. Variables are declared using the `var` keyword. The keywords are followed by the identifier, an optional [type annotation], an equals sign `=`, and the initial value:
 

--- a/docs/language/index.md
+++ b/docs/language/index.md
@@ -5,45 +5,36 @@ sidebar_label: Language Reference
 
 ## Introduction
 
-The Cadence Programming Language is a new high-level programming language
-intended for smart contract development.
+The Cadence Programming Language is a new high-level programming language intended for smart contract development.
 
 The language's goals are, in order of importance:
 
-- **Safety and security**:
-  Provide a strong static type system, design by contract (preconditions and postconditions),
-  and resources (inspired by linear types).
-
-- **Auditability**:
-  Focus on readability: Make it easy to verify what the code is doing,
-  and make intentions explicit, at a small cost of verbosity.
-
-- **Simplicity**: Focus on developer productivity and usability:
-  Make it easy to write code, provide good tooling.
+- **Safety and security** — Provide a strong static type system, design by contract (preconditions and postconditions), and resources (inspired by linear types).
+- **Auditability** — Focus on readability: Make it easy to verify what the code is doing, and make intentions explicit, at a small cost of verbosity.
+- **Simplicity** — Focus on developer productivity and usability: Make it easy to write code and provide good tooling.
 
 ## Terminology
 
-In this document, the following terminology is used to describe syntax
-or behavior that is not allowed in the language:
+In this document, the following terminology is used to describe syntax or behavior that is not allowed in the language:
 
-- `Invalid` means that the invalid program will not even be allowed to run.
-  The program error is detected and reported statically by the type checker.
+- `Invalid` means that the invalid program will not even be allowed to run. The program error is detected and reported statically by the type checker.
+- `Run-time error` means that the erroneous program will run, but bad behavior will result in the execution of the program being aborted.
 
-- `Run-time error` means that the erroneous program will run,
-  but bad behavior will result in the execution of the program being aborted.
-
-## Syntax and Behavior
+## Syntax and behavior
 
 Much of the language's syntax is inspired by Swift, Kotlin, and TypeScript.
 
-Much of the syntax, types, and standard library is inspired by Swift,
-which popularized e.g. optionals, argument labels,
-and provides safe handling of integers and strings.
+- Much of the syntax, types, and standard library is inspired by Swift, which popularized, for example,  optionals, argument labels, and provides safe handling of integers and strings.
+- Resources are based on linear, types which were popularized by Rust.
+- Events are inspired by Solidity.
 
-Resources are based on linear types which were popularized by Rust.
+:::info
 
-Events are inspired by Solidity.
+In real Cadence code, all type definitions and code must be declared and contained in [contracts] or [transactions], but we omit these containers in examples for simplicity.
 
-**Disclaimer:** In real Cadence code, all type definitions and code
-must be declared and contained in [contracts](./contracts.mdx) or [transactions](./transactions.md),
-but we omit these containers in examples for simplicity.
+:::
+
+<!-- Relative links. Will not render on the page -->
+
+[contracts]: ./contracts.mdx
+[transactions]: ./transactions.md

--- a/docs/language/index.md
+++ b/docs/language/index.md
@@ -24,7 +24,7 @@ In this document, the following terminology is used to describe syntax or behavi
 
 Much of the language's syntax is inspired by Swift, Kotlin, and TypeScript.
 
-- Much of the syntax, types, and standard library is inspired by Swift, which popularized, for example,  optionals, argument labels, and provides safe handling of integers and strings.
+- Much of the syntax, types, and standard library is inspired by Swift, which popularized features including optionals, argument labels, and provides safe handling of integers and strings.
 - Resources are based on linear types which were popularized by Rust.
 - Events are inspired by Solidity.
 

--- a/docs/language/index.md
+++ b/docs/language/index.md
@@ -24,7 +24,7 @@ In this document, the following terminology is used to describe syntax or behavi
 
 Much of the language's syntax is inspired by Swift, Kotlin, and TypeScript.
 
-- Much of the syntax, types, and standard library is inspired by Swift, which popularized features including optionals, argument labels, and provides safe handling of integers and strings.
+- Much of the syntax, types, and standard library is inspired by Swift, which popularized features including optionals and argument labels, and provides safe handling of integers and strings.
 - Resources are based on linear types which were popularized by Rust.
 - Events are inspired by Solidity.
 

--- a/docs/language/index.md
+++ b/docs/language/index.md
@@ -25,7 +25,7 @@ In this document, the following terminology is used to describe syntax or behavi
 Much of the language's syntax is inspired by Swift, Kotlin, and TypeScript.
 
 - Much of the syntax, types, and standard library is inspired by Swift, which popularized, for example,  optionals, argument labels, and provides safe handling of integers and strings.
-- Resources are based on linear, types which were popularized by Rust.
+- Resources are based on linear types which were popularized by Rust.
 - Events are inspired by Solidity.
 
 :::info

--- a/docs/language/syntax.md
+++ b/docs/language/syntax.md
@@ -5,11 +5,9 @@ sidebar_position: 1
 
 ## Comments
 
-Comments can be used to document code.
-A comment is text that is not executed.
+Comments can be used to document code. A comment is text that is not executed.
 
-*Single-line comments* start with two slashes (`//`).
-These comments can go on a line by themselves or they can go directly after a line of code.
+_Single-line comments_ start with two slashes (`//`). These comments can go on a line by themselves, or they can go directly after a line of code:
 
 ```cadence
 // This is a comment on a single line.
@@ -18,32 +16,30 @@ These comments can go on a line by themselves or they can go directly after a li
 let x = 1  // Here is another comment after a line of code.
 ```
 
-*Multi-line comments* start with a slash and an asterisk (`/*`)
-and end with an asterisk and a slash (`*/`):
+_Multi-line comments_ start with a slash and an asterisk (`/*`) and end with an asterisk and a slash (`*/`):
 
 ```cadence
 /* This is a comment which
 spans multiple lines. */
 ```
 
-Comments may be nested.
+Comments may be nested:
 
 ```cadence
 /* /* this */ is a valid comment */
 ```
 
-Multi-line comments are balanced.
+Multi-line comments are balanced:
 
 ```cadence
 /* this is a // comment up to here */ this is not part of the comment */
 ```
 
-### Documentation Comments
-Documentation comments (also known as "doc-strings" or "doc-comment") are a special set of comments that can be
-processed by tools, for example to generate human-readable documentation, or provide documentation in an IDE.
+### Documentation comments
 
-Doc-comments either start with three slashes (`///`) on each line,
-or are surrounded by `/**` and `**/`.
+Documentation comments (also known as _doc-strings_ or _doc-comment_) are a special set of comments that can be processed by tools (e.g., to generate human-readable documentation or provide documentation in an IDE).
+
+Doc-comments either start with three slashes (`///`) on each line or are surrounded by `/**` and `**/`:
 
 ```cadence
 /// This is a documentation comment for `x`.
@@ -61,11 +57,7 @@ let x = 1
 
 ## Identifiers
 
-Identifiers may start with any upper or lowercase letter (A-Z, a-z)
-or an underscore (`_`).
-This may be followed by zero or more upper and lower case letters,
-underscores, and numbers (0-9).
-Identifiers may not begin with a number.
+Identifiers can start with any upper or lowercase letter (A-Z, a-z) or an underscore (`_`). This may be followed by zero or more upper and lower case letters, underscores, and numbers (0-9). Identifiers can **not** begin with a number:
 
 ```cadence
 // Valid: title-case
@@ -111,27 +103,21 @@ The following identifiers are reserved, as they are keywords of the language:
 - `fun`, `pre`, `post`,
 - `auth`, `access`
 - `self`, `init`
-- `contract`, `event`, `struct`, `resource`, `interface`,
-  `entitlement`, `enum`, `mapping`, `attachment`, `result`
+- `contract`, `event`, `struct`, `resource`, `interface`, `entitlement`, `enum`, `mapping`, `attachment`, `result`
 - `transaction`, `prepare`, `execute`
 - `switch`, `case`, `default`
 - `import`, `include`
-- `require`, `requires`, `static`, `native`, `pub`, `priv`, `try`, `catch`, `finally`,
-  `goto`, `const`, `export`, `throw`, `throws`, `where`, `final`, `internal`, `typealias`,
-  `repeat`, `guard`, `is`
+- `require`, `requires`, `static`, `native`, `pub`, `priv`, `try`, `catch`, `finally`, `goto`, `const`, `export`, `throw`, `throws`, `where`, `final`, `internal`, `typealias`, `repeat`, `guard`, `is`
 
 ### Conventions
 
-By convention, variables, constants, and functions have lowercase identifiers;
-and types have title-case identifiers.
+By convention, variables, constants, and functions have lowercase identifiers, and types have title-case identifiers.
 
 ## Semicolons
 
-Semicolons (;) are used as separators between declarations and statements.
-A semicolon can be placed after any declaration and statement,
-but can be omitted between declarations and if only one statement appears on the line.
+Semicolons (`;`) are used as separators between declarations and statements. A semicolon can be placed after any declaration and statement, but can be omitted between declarations if only one statement appears on the line.
 
-Semicolons must be used to separate multiple statements if they appear on the same line.
+Semicolons must be used to separate multiple statements if they appear on the same line:
 
 ```cadence
 // Declare a constant, without a semicolon.


### PR DESCRIPTION
Hi, Brian — This PR edits the first three articles In the Language Reference section:

* https://cadence-lang.org/docs/language/
* https://cadence-lang.org/docs/language/syntax
* https://cadence-lang.org/docs/language/constants-and-variables

Talk to you soon!