### PR TITLE
Change & to @ in storage.check

### DIFF
--- a/docs/tutorial/03-resources.md
+++ b/docs/tutorial/03-resources.md
@@ -396,7 +396,7 @@ Depending on the needs of your app, you'll use this pattern to decide what to do
 1. Refactor your prepare statement to check and see if the storage path is in use. If it is, update the `result` message. Otherwise, create and save a `HelloAsset`:
 
    ```cadence
-   if acct.storage.check<&HelloResource.HelloAsset>(from: storagePath) {
+   if acct.storage.check<@HelloResource.HelloAsset>(from: storagePath) {
        self.result = "Unable to save, resource already present."
    } else {
        let newHello <- HelloResource.createHelloAsset()
@@ -426,7 +426,7 @@ Depending on the needs of your app, you'll use this pattern to decide what to do
        self.result = "Saved Hello Resource to account."
        let storagePath = /storage/HelloAssetTutorial
 
-       if acct.storage.check<&HelloResource.HelloAsset>(from: storagePath) {
+       if acct.storage.check<@HelloResource.HelloAsset>(from: storagePath) {
          self.result = "Unable to save, resource already present."
        } else {
          let newHello <- HelloResource.createHelloAsset()


### PR DESCRIPTION
This is a breaking bug from one of the intro do cadence tutorials.  It threw me off pretty early on in the learning Cadence process so think its important to patch it up.  The accompanying code in the flow playground also have this bug so the links within the tutorial that take you to those supplied code snippets in the playground should be fixed as well.