### PR TITLE
Edit remaining Cadence Migration guides

### DIFF
--- a/docs/cadence-migration-guide/core-contracts-guide.mdx
+++ b/docs/cadence-migration-guide/core-contracts-guide.mdx
@@ -4,31 +4,25 @@ sidebar_position: 4
 sidebar_label: Core Contracts Guide
 ---
 
-## Protocol Smart Contracts in Cadence 1.0
+# Protocol Smart Contracts in Cadence 1.0
 
-On September 4th, 2024 the Flow Mainnet upgraded to Cadence 1.0.
-In addition to many changes to the Cadence programming language and
-the Cadence token standards, the Flow Protocol smart contracts
-also updated to be compatible with the changes.
+:::important
 
-All applications that interact with these contracts need to update their transactions and scripts
-in order to be compatible with the changes.
+On September 4th, 2024, the Flow Mainnet upgraded to Cadence 1.0. In addition to many changes to the Cadence programming language and the Cadence token standards, the Flow Protocol smart contracts were also updated to be compatible with the changes.
 
-## Important Info
+All applications that interact with these contracts need to update their transactions and scripts in order to be compatible with these changes.
 
-This document assumes you have a basic understanding of the
-[Cadence 1.0 improvements](./improvements.md) and modifications to the Fungible Token Standard.
-We encourage you to consult those guides for more details on these changes if you are interested.
+:::
 
-The updated code for the Cadence 1.0 versions of the protocol smart contracts is located in the
-[`master` branch of the flow-core-contracts repo](https://github.com/onflow/flow-core-contracts).
-Please look at the [PR that made the changes](https://github.com/onflow/flow-core-contracts/pull/319)
-to understand how the contracts have changed. Every contract in the repo changed.
+## Important info
 
-Additionally, here are the import addresses
-for all of the important contracts related to the protocol:
+This document assumes you have a basic understanding of the [Cadence 1.0 improvements] and modifications to the Fungible Token Standard. We encourage you to consult those guides for more details on these changes if you are interested.
 
-| Contract                    | Emulator Import Address | Testing Framework    |
+The updated code for the Cadence 1.0 versions of the protocol smart contracts is located in the [`master` branch of the flow-core-contracts repo]. Please look at the [PR that made the changes] to understand how the contracts have changed. Every contract in the repo changed.
+
+Additionally, here are the import addresses for all of the important contracts related to the protocol:
+
+| Contract                    | Emulator import address | Testing framework    |
 | --------------------------- | ----------------------- | -------------------- |
 | `FungibleToken`             | `0xee82856bf20e2aa6`    | `0x0000000000000002` |
 | `ViewResolver`              | `0xf8d6e0586b0a20c7`    | `0x0000000000000001` |
@@ -49,16 +43,16 @@ for all of the important contracts related to the protocol:
 | `FlowEpoch`                 | `0xf8d6e0586b0a20c7`    | `0x0000000000000001` |
 | `FlowStakingCollection`     | `0xf8d6e0586b0a20c7`    | `0x0000000000000001` |
 
-See the other guides in this section of the docs for the import
-addresses of other important contracts in the emulator.
+See the other guides in this section of the docs for the import addresses of other important contracts in the emulator.
 
-## Upgrade Guide
+## Upgrade guide
 
-The NFT guide covers a lot of common changes that are required for NFT contracts,
-but many of these changes will also apply to any contract on Flow, so it is still
-useful to read even if you don't have an NFT contract.
+The NFT guide covers a lot of common changes that are required for NFT contracts, but many of these changes will also apply to any contract on Flow, so it is still useful to read even if you don't have an NFT contract.
 
-The core contracts do not have any meaningful changes outside of what is required
-to be compatible with Cadence 1.0 and the token standard changes.
-If you have questions about the core contracts changes for Cadence 1.0,
-please reach out to the Flow team in Discord and we will be happy to help.
+The core contracts do not have any meaningful changes outside of what is required to be compatible with Cadence 1.0 and the token standard changes. If you have questions about the core contracts changes for Cadence 1.0, please reach out to the Flow team in Discord and we will be happy to help.
+
+<!-- Relative links. Will not render on the page -->
+
+[Cadence 1.0 improvements]: ./improvements.md
+[`master` branch of the flow-core-contracts repo]: https://github.com/onflow/flow-core-contracts
+[PR that made the changes]: https://github.com/onflow/flow-core-contracts/pull/319

--- a/docs/cadence-migration-guide/ft-guide.mdx
+++ b/docs/cadence-migration-guide/ft-guide.mdx
@@ -6,45 +6,25 @@ sidebar_label: FT Cadence 1.0 Guide
 
 # Fungible Tokens in Cadence 1.0
 
-On September 4th, 2024 the Flow Mainnet upgraded to Cadence 1.0.
-In addition to many changes to the Cadence programming language,
-the Cadence token standards also got streamlined and improved.
-All applications need to migrate their existing Cadence scripts and transactions for the update.
-If you do not update your code, your application will not function.
+:::important
 
-This document describes the changes to the Cadence Fungible Token (FT) standard.
-We'll be using the
-[`ExampleToken` contract](https://github.com/onflow/flow-ft/blob/master/contracts/ExampleToken.cdc)
-as an example. Many projects have used `ExampleToken` as a starting point for their projects,
-so it is widely applicable to most NFT developers on Flow.
-The upgrades required for `ExampleToken` will cover 90%+ of what you'll
-need to do to update your contract. Each project most likely has
-additional logic or features that aren't included in `ExampleToken`,
-but hopefully after reading this guide, you'll understand Cadence 1.0
-well enough that you can easily make any other changes that are necessary.
+On September 4th, 2024, the Flow Mainnet upgraded to Cadence 1.0. In addition to many changes to the Cadence programming language, the Cadence token standards also got streamlined and improved. All applications need to migrate their existing Cadence scripts and transactions for the update. If you do not update your code, your application will not function.
 
-As always, there are plenty of people on the Flow team and in the community
-who are happy to help answer any questions you may have, so please reach out
-in Discord if you need any help.
+:::
 
-# Important Info
+This document describes the changes to the Cadence Fungible Token (FT) standard. We'll be using the [`ExampleToken` contract] as an example. Many projects have used `ExampleToken` as a starting point for their projects, so it is widely applicable to most NFT developers on Flow. The upgrades required for `ExampleToken` will cover 90%+ of what you'll need to do to update your contract. Each project most likely has additional logic or features that aren't included in `ExampleToken`, but hopefully, after reading this guide, you'll understand Cadence 1.0 well enough that you can easily make any other changes that are necessary.
 
-Please read [the FLIP](https://github.com/onflow/flips/pull/55)
-that describes the changes to the `FungibleToken` standard first.
+As always, there are plenty of people on the Flow team and in the community who are happy to help answer any questions you may have, so please reach out in Discord if you need any help.
 
-The updated code for the V2 Fungible Token standard is located in the
-[`master` branch of the flow-ft repo](https://github.com/onflow/flow-ft).
-Please look at the [PR that made the changes](https://github.com/onflow/flow-ft/pull/131)
-to understand how the standard and examples have changed.
-Note the changes to the `FungibleTokenMetadataViews`,
-`Burner`, `FungibleTokenSwitchboard`, and `TokenForwarding` contracts.
+## Important info
 
-Additionally, here are the import addresses
-for all of the important contracts related to fungible tokens.
-The second column is the import address if you are testing with a basic version of the emulator.
-The third column contains the import addresses if you are using the Cadence testing framework.
+Please read the [FLIP] that describes the changes to the `FungibleToken` standard first.
 
-| Contract                    | Emulator Import Address | Testing Framework    |
+The updated code for the V2 Fungible Token standard is located in the [`master` branch of the flow-ft repo]. Please look at the [PR that made the changes] to understand how the standard and examples have changed. Note the changes to the `FungibleTokenMetadataViews`, `Burner`, `FungibleTokenSwitchboard`, and `TokenForwarding` contracts.
+
+Additionally, here are the import addresses for all of the important contracts related to fungible tokens. The second column is the import address if you are testing with a basic version of the emulator. The third column contains the import addresses if you are using the Cadence testing framework:
+
+| Contract                    | Emulator import address | Testing framework    |
 | --------------------------- | ----------------------- | -------------------- |
 | `FungibleToken`             | `0xee82856bf20e2aa6`    | `0x0000000000000002` |
 | `ViewResolver`              | `0xf8d6e0586b0a20c7`    | `0x0000000000000001` |
@@ -53,47 +33,46 @@ The third column contains the import addresses if you are using the Cadence test
 | `FungibleTokenMetadataViews`| `0xee82856bf20e2aa6`    | `0x0000000000000002` |
 | `FungibleTokenSwitchboard`  | `0xee82856bf20e2aa6`    | `0x0000000000000002` |
 
-See the other guides in this section of the docs for the import
-addresses of other important contracts in the emulator.
+See the other guides in this section of the docs for the import addresses of other important contracts in the emulator.
 
-As for contracts that are important for NFT developers but aren't "core contracts",
-here is information about where to find the Cadence 1.0 versions of each:
+As for contracts that are important for NFT developers but aren't _core contracts_, here is information about where to find the Cadence 1.0 versions of each:
 
-**USDC:** USDC was migrated to standard bridged USDC on Flow. See the [repo](https://github.com/onflow/bridged-usdc) for the latest version of the USDC contract.
+- **USDC** — USDC was migrated to standard bridged USDC on Flow. See the [repo] for the latest version of the USDC contract.
+- **Account Linking and Hybrid Custody** — See [this PR in the hybrid custody repo] for updated hybrid custody contracts.
 
-**Account Linking and Hybrid Custody:**
-See [this PR in the hybrid custody repo](https://github.com/onflow/hybrid-custody/pull/164)
-for updated hybrid custody contracts.
+[This Discord announcement] also contains versions of a lot of important contracts.
 
-[This Discord announcement](https://discord.com/channels/613813861610684416/811693600403357706/1225909248429527140)
-also contains versions of a lot of important contracts.
+Use the [Flow Contract Browser] to find the 1.0 code of other contracts.
 
-Use the [Flow Contract Browser](https://contractbrowser.com/) to find the 1.0 code of other contracts.
+## Migration guide
 
-# Migration Guide
-
-Please see the [NFT Cadence 1.0 migration guide](./nft-guide.mdx).
-While the contracts aren't exactly the same, they share a huge amount of functionality,
-and the changes described in that guide will cover 90% of the changes
-that are needed for fungible tokens, so if you just follow those instructions
-for your fungible token contract, you'll be most of the way there.
+Please see the [NFT Cadence 1.0 migration guide]. While the contracts aren't exactly the same, they share a large amount of functionality, and the changes described in that guide will cover 90% of the changes that are needed for fungible tokens, so if you just follow those instructions for your fungible token contract, you'll be most of the way there.
 
 Here, we will only describe the changes that are specific to the fungible token standard.
 
-## `Vault` implements `FungibleToken.Vault`
+### `Vault` implements `FungibleToken.Vault`
 
-`FungibleToken.Vault` is no longer a resource type specification.
-It is now an interface that inherits from `Provider`, `Receiver`, `Balance`,
-`ViewResolver.Resolver`, and `Burner.Burnable`.
+`FungibleToken.Vault` is no longer a resource type specification. It is now an interface that inherits from `Provider`, `Receiver`, `Balance`, `ViewResolver.Resolver`, and `Burner Burnable`.
 
-Since `Vault` is an interface, you will need to update every instance in your code
-that refers to `@FungibleToken.Vault` or `&FungibleToken.Vault` to
-`@{FungibleToken.Vault}` or `&{FungibleToken.Vault}` respectively to show
-that it is now an interface specification instead of a concrete type specification.
-Example in `deposit()`:
+Since `Vault` is an interface, you will need to update every instance in your code that refers to `@FungibleToken.Vault` or `&FungibleToken.Vault` to `@{FungibleToken.Vault}` or `&{FungibleToken.Vault}` respectively to show that it is now an interface specification instead of a concrete type specification. 
+
+Here's an example in `deposit()`:
+
 ```cadence
 /// deposit now accepts a resource that implements the `FungibleToken.Vault` interface type
 access(all) fun deposit(from: @{FungibleToken.Vault})
 ```
 
 If you have any more questions, please ask in discord and the Flow team will be happy to assist!
+
+<!-- Relative links. Will not render on the page -->
+
+[`ExampleToken` contract]: https://github.com/onflow/flow-ft/blob/master/contracts/ExampleToken.cdc
+[FLIP]: https://github.com/onflow/flips/pull/55
+[`master` branch of the flow-ft repo]: https://github.com/onflow/flow-ft
+[PR that made the changes]: https://github.com/onflow/flow-ft/pull/131
+[repo]: https://github.com/onflow/bridged-usdc
+[this PR in the hybrid custody repo]: https://github.com/onflow/hybrid-custody/pull/164
+[This Discord announcement]: https://discord.com/channels/613813861610684416/811693600403357706/1225909248429527140
+[Flow Contract Browser]: https://contractbrowser.com/
+[NFT Cadence 1.0 migration guide]: ./nft-guide.mdx

--- a/docs/cadence-migration-guide/nft-guide.mdx
+++ b/docs/cadence-migration-guide/nft-guide.mdx
@@ -6,52 +6,29 @@ sidebar_label: NFT Cadence 1.0 Guide
 
 # Non-Fungible Tokens in Cadence 1.0
 
-On September 4th, 2024 the Flow Mainnet upgraded to Cadence 1.0.
-In addition to many changes to the Cadence programming language,
-the Cadence token standards were also streamlined and improved.
-All applications' scripts and transactions need to be updated.
-If you do not update your code, your applications do not function properly.
+:::important
 
-This document describes the changes to the Cadence Non-Fungible Token (NFT) standard and
-gives a step-by-step guide for how to upgrade your NFT contract from Cadence 0.42
-to Cadence 1.0.
+On September 4th, 2024, the Flow Mainnet upgraded to Cadence 1.0. In addition to many changes to the Cadence programming language, the Cadence token standards were also streamlined and improved. All applications' scripts and transactions need to be updated. If you do not update your code, your applications will not function properly.
 
-We'll be using the
-[`ExampleNFT` contract](https://github.com/onflow/flow-nft/blob/master/contracts/ExampleNFT.cdc)
-as an example. Many projects have used `ExampleNFT` as a starting point for their projects,
-so it is widely applicable to most NFT developers on Flow.
-The upgrades required for `ExampleNFT` will cover 90%+ of what you'll
-need to do to update your contract. Each project most likely has
-additional logic or features that aren't included in `ExampleNFT`,
-but hopefully after reading this guide, you'll understand Cadence 1.0
-well enough that you can easily make any other changes that are necessary.
+:::
 
-Additionally, most of the changes described here also apply to anyone
-who is updating a Fungible Token contract or interacting with one,
-so keep that in mind while reading if that applies to you.
+This document describes the changes to the Cadence Non-Fungible Token (NFT) standard and gives a step-by-step guide for how to upgrade your NFT contract from Cadence 0.42 to Cadence 1.0.
 
-As always, there are plenty of people on the Flow team and in the community
-who are happy to help answer any questions you may have, so please reach out
-in Discord if you need any help.
+We'll be using the [`ExampleNFT` contract] as an example. Many projects have used `ExampleNFT` as a starting point for their projects, so it is widely applicable to most NFT developers on Flow. The upgrades required for `ExampleNFT` will cover 90%+ of what you'll need to do to update your contract. Each project most likely has additional logic or features that aren't included in `ExampleNFT`, but hopefully, after reading this guide, you'll understand Cadence 1.0 well enough that you can easily make any other changes that are necessary.
 
-# Important Info
+Additionally, most of the changes described here also apply to anyone who is updating a Fungible Token contract or interacting with one, so keep that in mind while reading if that applies to you.
 
-Please read [the FLIP](https://github.com/onflow/flips/pull/56)
-that describes the changes to the `NonFungibleToken` standard first.
+As always, there are plenty of people on the Flow team and in the community who are happy to help answer any questions you may have, so please reach out in Discord if you need any help.
 
-The updated code for the V2 Non-Fungible Token standard is located in the
-[`master` branch of the flow-nft repo](https://github.com/onflow/flow-nft).
-Please look at [the PR that made the changes](https://github.com/onflow/flow-nft/pull/126)
-to understand how the standard and examples have changed.
-Note the changes to the `NonFungibleToken`, `MetadataViews`, `ViewResolver`,
-and `NFTForwarding` contracts.
+## Important information
 
-Additionally, here are the import addresses
-for all of the important contracts related to non-fungible tokens.
-The second column is the import address if you are testing with a basic version of the emulator.
-The third column contains the import addresses if you are using the Cadence testing framework.
+Please read the [NFT-V2 FLIP] that describes the changes to the `NonFungibleToken` standard first.
 
-| Contract           | Emulator Import Address | Testing Framework    |
+The updated code for the V2 Non-Fungible Token standard is located in the [`master` branch of the flow-nft repo]. Please look at the [PR that made the changes] to understand how the standard and examples have changed. Note the changes to the `NonFungibleToken`, `MetadataViews`, `ViewResolver`, and `NFTForwarding` contracts.
+
+Additionally, here are the import addresses for all of the important contracts related to non-fungible tokens. The second column is the import address if you are testing with a basic version of the emulator. The third column contains the import addresses if you are using the Cadence testing framework:
+
+| Contract           | Emulator import address | Testing framework    |
 | ------------------ | ----------------------- | -------------------- |
 | `NonFungibleToken` | `0xf8d6e0586b0a20c7`    | `0x0000000000000001` |
 | `FungibleToken`    | `0xee82856bf20e2aa6`    | `0x0000000000000002` |
@@ -59,60 +36,34 @@ The third column contains the import addresses if you are using the Cadence test
 | `Burner`           | `0xf8d6e0586b0a20c7`    | `0x0000000000000001` |
 | `MetadataViews`    | `0xf8d6e0586b0a20c7`    | `0x0000000000000001` |
 
-See the other guides in this section of the docs for the import
-addresses of other important contracts in the emulator.
+See the other guides in this section of the docs for the import addresses of other important contracts in the emulator.
 
-As for contracts that are important for NFT developers but aren't "core contracts",
-here is information about where to find the Cadence 1.0 Versions of Each:
+As for contracts that are important for NFT developers but aren't _core contracts_, here is information about where to find the Cadence 1.0 versions of each:
 
-**NFT Catalog:** The NFT Catalog has been deprecated for Cadence 1.0. Now that the token standards require implementing metadata views, NFT Catalog is not needed in its current form. The Flow team now maintains [TokenList](https://token-list.fixes.world/?utm_source=Flowverse&utm_medium=Website&utm_campaign=Dapp) which is similar to NFT Catalog, but is decentralized. Projects can register there without needing to be approved.
+- **NFT Catalog** — The NFT Catalog has been deprecated for Cadence 1.0. Now that the token standards require implementing metadata views, NFT Catalog is not needed in its current form. The Flow team now maintains [TokenList], which is similar to NFT Catalog but is decentralized. Projects can register there without needing to be approved.
+- **NFT Storefront** — See the [`master` branch in the NFT Storefront Repo] for the updated versions of the `NFTStorefront` and `NFTStorefrontV2` contracts.
+- **USDC** — USDC was migrated to standard bridged USDC on Flow. See the [repo] for the latest version of the USDC contract.
+- **Account Linking and Hybrid Custody** — See the [`main` branch in the hybrid custody repo] for updated hybrid custody contracts.
 
-**NFT Storefront:**
-See [the `master` branch in the NFT Storefront Repo](https://github.com/onflow/nft-storefront/tree/master/contracts)
-for the updated versions of the `NFTStorefront` and `NFTStorefrontV2` contracts.
+[This Discord announcement] also contains versions of a lot of important contracts.
 
-**USDC:** USDC was migrated to standard bridged USDC on Flow. See the [repo](https://github.com/onflow/bridged-usdc) for the latest version of the USDC contract.
-
-**Account Linking and Hybrid Custody:**
-See [the `main` branch in the hybrid custody repo](https://github.com/onflow/hybrid-custody)
-for updated hybrid custody contracts.
-
-[This Discord announcement](https://discord.com/channels/613813861610684416/811693600403357706/1225909248429527140)
-also contains versions of a lot of important contracts.
-
-Use the [Flow Contract Browser](https://contractbrowser.com/) to find the 1.0 code of other contracts.
+Use the [Flow Contract Browser] to find the 1.0 code of other contracts.
 
 ## A note for newcomers
 
-This guide is primarily for developers who have existing contracts
-deployed to Flow mainnet that they need to update for Cadence 1.0.
-If you don't have any contracts deployed yet, it is recommended that
-you start an NFT contract from scratch by either copying the `ExampleNFT` contract 
-from the `master` branch of the `flow-nft` repo.
+This guide is primarily for developers who have existing contracts deployed to Flow mainnet that they need to update for Cadence 1.0. If you don't have any contracts deployed yet, it is recommended that you start an NFT contract from scratch by either copying the `ExampleNFT` contract from the `master` branch of the `flow-nft` repo.
 
-Additionally, the Flow community is working on 
-the [`BasicNFT` contract](https://github.com/onflow/flow-nft/blob/universal-collection/contracts/BasicNFT.cdc)
-in the `universal-collection` branch of the flow-nft GitHub repo.
-This is a simplified version of standard NFT contracts, but has not been completed yet.
+Additionally, the Flow community is working on  the [`BasicNFT` contract] in the `universal-collection` branch of the flow-nft GitHub repo. This is a simplified version of standard NFT contracts, but has not been completed yet.
 
-## BasicNFT and UniversalCollection
+## `BasicNFT` and `UniversalCollection`
 
-As part of the improvements to the NFT standard, there is now a new NFT contract
-example in the `flow-nft` GitHub repo: [`BasicNFT`](https://github.com/onflow/flow-nft/blob/universal-collection/contracts/BasicNFT.cdc).
+As part of the improvements to the NFT standard, there is now a new NFT contract example in the `flow-nft` GitHub repo:
 
-`BasicNFT` defines a Cadence NFT in as few lines of code as possible, 137 at the moment!
-This is possible because the contract basically only defines the NFT resource,
-the essential metadata views, and a minter resource.
-It doesn't have to define a collection! Most collection resources are 99% boilerplate
-code, so it really doesn't make sense for most projects to have to define their own
-collection.
+- [`BasicNFT` contract].
 
-Instead, `BasicNFT` uses [`UniversalCollection`](https://github.com/onflow/flow-nft/blob/universal-collection/contracts/UniversalCollection.cdc),
-a contract that defines a collection resource
-that has all of the standard functionality that a collection needs and nothing else.
-From now on, any project that doesn't want to do anything unique with their collection
-can just import `UniversalCollection` and call it from their `createEmptyCollection`
-function:
+`BasicNFT` defines a Cadence NFT in as few lines of code as possible, 137 at the moment! This is possible because the contract basically only defines the NFT resource, the essential metadata views, and a minter resource. It doesn't have to define a collection! Most collection resources are 99% boilerplate code, so it really doesn't make sense for most projects to have to define their own collection.
+
+Instead, `BasicNFT` uses [`UniversalCollection`], a contract that defines a collection resource that has all of the standard functionality that a collection needs and nothing else. From now on, any project that doesn't want to do anything unique with their collection can just import `UniversalCollection` and call it from their `createEmptyCollection` function:
 
 ```cadence
 access(all) fun createEmptyCollection(nftType: Type): @{NonFungibleToken.Collection} {
@@ -120,9 +71,7 @@ access(all) fun createEmptyCollection(nftType: Type): @{NonFungibleToken.Collect
 }
 ```
 
-All they have to provide is a type and an identifier for the collection.
-`UniversalCollection.Collection` will enforce that only NFTs of the given type
-can be accepted by the collection:
+All they have to provide is a type and an identifier for the collection. `UniversalCollection.Collection` will enforce that only NFTs of the given type can be accepted by the collection:
 
 ```cadence
 access(all) fun deposit(token: @{NonFungibleToken.NFT}) {
@@ -133,48 +82,47 @@ access(all) fun deposit(token: @{NonFungibleToken.NFT}) {
 
 It also constructs standard paths based on the identifier provided.
 
-`UniversalCollection` will be deployed to all the networks soon after the Cadence 1.0 upgrade,
-so developers will be able to import from it after that point.
+`UniversalCollection` will be deployed to all of the networks soon after the Cadence 1.0 upgrade, so developers will be able to import from it after that point.
 
-We'll be putting out more information and guides for `BasicNFT` and `UniversalCollection`
-in the near future, but keep it in mind if you are thinking about deploying
-any new NFT contracts in the future!
+We'll be putting out more information and guides for `BasicNFT` and `UniversalCollection` in the near future, but keep it in mind if you are thinking about deploying any new NFT contracts in the future!
 
-# Migration Guide
+## Migration guide
 
-This guide will cover changes that are required because of upgrades to
-the Cadence Language as well as the token standard.
-The improvements will be described here as they apply to specific changes
-that projects need to make in order to be ready for the upgrade,
-but it is good to read all sources to fully understand the changes.
+This guide will cover changes that are required because of upgrades to the Cadence programming language as well as the token standard. The improvements are described here as they apply to specific changes that projects need to make in order to be ready for the upgrade, but it is good to read all sources to fully understand the changes.
 
-Please read the motivation section of [the NFT-V2 FLIP](https://github.com/onflow/flips/pull/56)
-to learn about why most of the changes to the standard were needed or desired.
+Please read the motivation section of the [NFT-V2 FLIP] to learn about why most of the changes to the standard were needed or desired.
 
-First, we will cover the changes that come from the new token standards and then
-we will cover the changes that come from Cadence.
+First, we will cover the changes that come from the new token standards and then we will cover the changes that come from Cadence.
 
-## Token Standard Changes
+### Token Standard Changes
 
-### NonFungibleToken.NFT
+**`NonFungibleToken.NFT`**
 
 `NonFungibleToken.NFT` used to be a nested type specification, but now it is an interface!
 
-In your code, any instance that refers
-to `@NonFungibleToken.NFT` or `&NonFungibleToken.NFT` need to be updated to
-`@{NonFungibleToken.NFT}` or `&{NonFungibleToken.NFT}` respectively.
+In your code, any instance that refers to `@NonFungibleToken.NFT` or `&NonFungibleToken.NFT` must be updated to `@{NonFungibleToken.NFT}` or `&{NonFungibleToken.NFT}` respectively.
 
-### NonFungibleToken.Collection
+**`NonFungibleToken.Collection`**
 
 Similar to `NFT`, `NonFungibleToken.Collection` is now an interface.
 
-Since `Collection` is an interface, you will need to update every instance in your code
-that refers to `@NonFungibleToken.Collection` or `&NonFungibleToken.Collection` to
-`@{NonFungibleToken.Collection}` or `&{NonFungibleToken.Collection}` respectively to show
-that it is now an interface specification instead of a concrete type specification.
+Since `Collection` is an interface, you will need to update every instance in your code that refers to `@NonFungibleToken.Collection` or `&NonFungibleToken.Collection` to `@{NonFungibleToken.Collection}` or `&{NonFungibleToken.Collection}` respectively to show that it is now an interface specification instead of a concrete type specification.
 
 ## Conclusion
 
-This guide covered the most important changes that are required for the Cadence 1.0
-upgrades to NFT contracts. Please ask any questions about the migrations
-in the #developer-questions channel in discord and good luck with your upgrades!
+This guide covered the most important changes that are required for the Cadence 1.0 upgrades to NFT contracts. Please ask any questions about the migrations in the #developer-questions channel in discord and good luck with your upgrades!
+
+<!-- Relative links. Will not render on the page -->
+
+[`ExampleNFT` contract]: https://github.com/onflow/flow-nft/blob/master/contracts/ExampleNFT.cdc
+[`master` branch of the flow-nft repo]: https://github.com/onflow/flow-nft
+[PR that made the changes]: https://github.com/onflow/flow-nft/pull/126
+[TokenList]: https://token-list.fixes.world/?utm_source=Flowverse&utm_medium=Website&utm_campaign=Dapp
+[`master` branch in the NFT Storefront Repo]: https://github.com/onflow/nft-storefront/tree/master/contracts
+[repo]: https://github.com/onflow/bridged-usdc
+[`main` branch in the hybrid custody repo]: https://github.com/onflow/hybrid-custody
+[This Discord announcement]: https://discord.com/channels/613813861610684416/811693600403357706/1225909248429527140
+[Flow Contract Browser]: https://contractbrowser.com/
+[`BasicNFT` contract]: https://github.com/onflow/flow-nft/blob/universal-collection/contracts/BasicNFT.cdc
+[`UniversalCollection`]: https://github.com/onflow/flow-nft/blob/universal-collection/contracts/UniversalCollection.cdc
+[NFT-V2 FLIP]: https://github.com/onflow/flips/pull/56


### PR DESCRIPTION
This PR edits the remaining Cadence 1.0 Migration Guides:
* [NFT Cadence 1.0 Guide](https://cadence-lang.org/docs/cadence-migration-guide/nft-guide)
* [FT Cadence 1.0 Guide](https://cadence-lang.org/docs/cadence-migration-guide/ft-guide)
* [Core Contracts Guide](https://cadence-lang.org/docs/cadence-migration-guide/core-contracts-guide)